### PR TITLE
Make admin users or groups required when creating AKS cluster

### DIFF
--- a/aks/terraform/modules/cluster/main.tf
+++ b/aks/terraform/modules/cluster/main.tf
@@ -114,7 +114,10 @@ resource "azurerm_kubernetes_cluster" "cluster" {
   ]
 
   lifecycle {
-    ignore_changes = [kubernetes_version]
+    precondition {
+      condition     = !var.local_account_disabled || length(var.kubernetes_cluster_admin_groups) > 0 || length(var.kubernetes_cluster_admin_users) > 0
+      error_message = "At least one admin group or admin user must be provided if local accounts are disabled."
+    }
   }
 }
 

--- a/eks/terraform/modules/broker-node-group/main.tf
+++ b/eks/terraform/modules/broker-node-group/main.tf
@@ -56,8 +56,7 @@ resource "aws_eks_node_group" "this" {
 
   lifecycle {
     ignore_changes = [
-      scaling_config[0].desired_size,
-      launch_template[0].version
+      scaling_config[0].desired_size
     ]
   }
 }

--- a/eks/terraform/modules/cluster/main.tf
+++ b/eks/terraform/modules/cluster/main.tf
@@ -195,8 +195,6 @@ resource "aws_eks_cluster" "cluster" {
   ]
 
   lifecycle {
-    ignore_changes = [version]
-
     precondition {
       condition     = !var.kubernetes_api_public_access || length(var.kubernetes_api_authorized_networks) > 0
       error_message = "At least one authorized network must be provided if public Kubernetes API is being created."
@@ -467,8 +465,7 @@ resource "aws_eks_node_group" "default" {
 
   lifecycle {
     ignore_changes = [
-      scaling_config[0].desired_size,
-      launch_template[0].version
+      scaling_config[0].desired_size
     ]
   }
 }

--- a/gke/terraform/modules/bastion/main.tf
+++ b/gke/terraform/modules/bastion/main.tf
@@ -49,10 +49,6 @@ resource "google_compute_instance" "bastion" {
   }
 
   lifecycle {
-    ignore_changes = [
-      zone,
-    ]
-
     precondition {
       condition     = var.bastion_ssh_public_key != ""
       error_message = "Public key must be provided if bastion host is being created."

--- a/gke/terraform/modules/broker-node-pool/main.tf
+++ b/gke/terraform/modules/broker-node-pool/main.tf
@@ -45,13 +45,4 @@ resource "google_container_node_pool" "this" {
     min_node_count  = 0
     max_node_count  = var.node_pool_max_size
   }
-
-  lifecycle {
-    ignore_changes = [
-      id,
-      node_config[0].metadata,
-      location,
-      node_locations
-    ]
-  }
 }

--- a/gke/terraform/modules/cluster/main.tf
+++ b/gke/terraform/modules/cluster/main.tf
@@ -89,16 +89,6 @@ resource "google_container_cluster" "cluster" {
   release_channel {
     channel = "UNSPECIFIED"
   }
-
-  lifecycle {
-    ignore_changes = [
-      network,
-      subnetwork,
-      ip_allocation_policy[0],
-      min_master_version,
-      location
-    ]
-  }
 }
 
 ################################################################################
@@ -139,14 +129,6 @@ resource "google_container_node_pool" "system" {
   }
 
   node_count = 1
-
-  lifecycle {
-    ignore_changes = [
-      id,
-      node_config[0].metadata,
-      location
-    ]
-  }
 }
 
 module "node_group_prod1k" {

--- a/gke/terraform/modules/network/main.tf
+++ b/gke/terraform/modules/network/main.tf
@@ -20,7 +20,7 @@ resource "google_compute_subnetwork" "cluster" {
   private_ip_google_access = true
 
   lifecycle {
-    ignore_changes = [secondary_ip_range]
+    ignore_changes = [secondary_ip_range] # these are automatically added by gke
 
     precondition {
       condition     = can(cidrhost(var.network_cidr_range, 0))


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

When an AKS cluster is created using default variables, local admin users are disabled (which is good and secure) but admin groups or users are not required so no one actually has access to the cluster. This PR adds a check for at least one user or group when creating the cluster when local admin is disabled.

#### Which issue(s) this PR fixes:

Fixes #9 

#### Special notes for your reviewer:
