### PR TITLE
Update terraform provider versions, uprev tests to use kubernetes 1.28

### DIFF
--- a/aks/terraform/modules/bastion/README.md
+++ b/aks/terraform/modules/bastion/README.md
@@ -4,13 +4,13 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.3 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | 3.91.0 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | 3.94.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.91.0 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.94.0 |
 
 ## Modules
 
@@ -20,11 +20,11 @@ No modules.
 
 | Name | Type |
 |------|------|
-| [azurerm_network_interface.bastion](https://registry.terraform.io/providers/hashicorp/azurerm/3.91.0/docs/resources/network_interface) | resource |
-| [azurerm_network_interface_security_group_association.bastion](https://registry.terraform.io/providers/hashicorp/azurerm/3.91.0/docs/resources/network_interface_security_group_association) | resource |
-| [azurerm_network_security_group.bastion](https://registry.terraform.io/providers/hashicorp/azurerm/3.91.0/docs/resources/network_security_group) | resource |
-| [azurerm_public_ip.bastion](https://registry.terraform.io/providers/hashicorp/azurerm/3.91.0/docs/resources/public_ip) | resource |
-| [azurerm_virtual_machine.bastion](https://registry.terraform.io/providers/hashicorp/azurerm/3.91.0/docs/resources/virtual_machine) | resource |
+| [azurerm_network_interface.bastion](https://registry.terraform.io/providers/hashicorp/azurerm/3.94.0/docs/resources/network_interface) | resource |
+| [azurerm_network_interface_security_group_association.bastion](https://registry.terraform.io/providers/hashicorp/azurerm/3.94.0/docs/resources/network_interface_security_group_association) | resource |
+| [azurerm_network_security_group.bastion](https://registry.terraform.io/providers/hashicorp/azurerm/3.94.0/docs/resources/network_security_group) | resource |
+| [azurerm_public_ip.bastion](https://registry.terraform.io/providers/hashicorp/azurerm/3.94.0/docs/resources/public_ip) | resource |
+| [azurerm_virtual_machine.bastion](https://registry.terraform.io/providers/hashicorp/azurerm/3.94.0/docs/resources/virtual_machine) | resource |
 
 ## Inputs
 

--- a/aks/terraform/modules/bastion/README.md
+++ b/aks/terraform/modules/bastion/README.md
@@ -4,13 +4,13 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.3 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | 3.81.0 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | 3.91.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.81.0 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.91.0 |
 
 ## Modules
 
@@ -20,11 +20,11 @@ No modules.
 
 | Name | Type |
 |------|------|
-| [azurerm_network_interface.bastion](https://registry.terraform.io/providers/hashicorp/azurerm/3.81.0/docs/resources/network_interface) | resource |
-| [azurerm_network_interface_security_group_association.bastion](https://registry.terraform.io/providers/hashicorp/azurerm/3.81.0/docs/resources/network_interface_security_group_association) | resource |
-| [azurerm_network_security_group.bastion](https://registry.terraform.io/providers/hashicorp/azurerm/3.81.0/docs/resources/network_security_group) | resource |
-| [azurerm_public_ip.bastion](https://registry.terraform.io/providers/hashicorp/azurerm/3.81.0/docs/resources/public_ip) | resource |
-| [azurerm_virtual_machine.bastion](https://registry.terraform.io/providers/hashicorp/azurerm/3.81.0/docs/resources/virtual_machine) | resource |
+| [azurerm_network_interface.bastion](https://registry.terraform.io/providers/hashicorp/azurerm/3.91.0/docs/resources/network_interface) | resource |
+| [azurerm_network_interface_security_group_association.bastion](https://registry.terraform.io/providers/hashicorp/azurerm/3.91.0/docs/resources/network_interface_security_group_association) | resource |
+| [azurerm_network_security_group.bastion](https://registry.terraform.io/providers/hashicorp/azurerm/3.91.0/docs/resources/network_security_group) | resource |
+| [azurerm_public_ip.bastion](https://registry.terraform.io/providers/hashicorp/azurerm/3.91.0/docs/resources/public_ip) | resource |
+| [azurerm_virtual_machine.bastion](https://registry.terraform.io/providers/hashicorp/azurerm/3.91.0/docs/resources/virtual_machine) | resource |
 
 ## Inputs
 

--- a/aks/terraform/modules/bastion/main.tf
+++ b/aks/terraform/modules/bastion/main.tf
@@ -78,7 +78,7 @@ resource "azurerm_virtual_machine" "bastion" {
   location              = var.region
   resource_group_name   = var.resource_group_name
   network_interface_ids = [azurerm_network_interface.bastion[0].id]
-  vm_size               = "Standard_B1ls"
+  vm_size               = "Standard_B1s"
 
   delete_os_disk_on_termination = true
 

--- a/aks/terraform/modules/bastion/main.tf
+++ b/aks/terraform/modules/bastion/main.tf
@@ -10,6 +10,7 @@ resource "azurerm_public_ip" "bastion" {
   location            = var.region
   resource_group_name = var.resource_group_name
   allocation_method   = "Static"
+  sku                 = "Standard"
 }
 
 resource "azurerm_network_security_group" "bastion" {

--- a/aks/terraform/modules/bastion/versions.tf
+++ b/aks/terraform/modules/bastion/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "3.91.0"
+      version = "3.94.0"
     }
   }
 }

--- a/aks/terraform/modules/bastion/versions.tf
+++ b/aks/terraform/modules/bastion/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "3.81.0"
+      version = "3.91.0"
     }
   }
 }

--- a/aks/terraform/modules/broker-node-pool/README.md
+++ b/aks/terraform/modules/broker-node-pool/README.md
@@ -4,13 +4,13 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.3 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | 3.91.0 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | 3.94.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.91.0 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.94.0 |
 
 ## Modules
 
@@ -20,7 +20,7 @@ No modules.
 
 | Name | Type |
 |------|------|
-| [azurerm_kubernetes_cluster_node_pool.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.91.0/docs/resources/kubernetes_cluster_node_pool) | resource |
+| [azurerm_kubernetes_cluster_node_pool.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.94.0/docs/resources/kubernetes_cluster_node_pool) | resource |
 
 ## Inputs
 

--- a/aks/terraform/modules/broker-node-pool/README.md
+++ b/aks/terraform/modules/broker-node-pool/README.md
@@ -4,13 +4,13 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.3 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | 3.81.0 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | 3.91.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.81.0 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.91.0 |
 
 ## Modules
 
@@ -20,7 +20,7 @@ No modules.
 
 | Name | Type |
 |------|------|
-| [azurerm_kubernetes_cluster_node_pool.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.81.0/docs/resources/kubernetes_cluster_node_pool) | resource |
+| [azurerm_kubernetes_cluster_node_pool.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.91.0/docs/resources/kubernetes_cluster_node_pool) | resource |
 
 ## Inputs
 

--- a/aks/terraform/modules/broker-node-pool/versions.tf
+++ b/aks/terraform/modules/broker-node-pool/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "3.91.0"
+      version = "3.94.0"
     }
   }
 }

--- a/aks/terraform/modules/broker-node-pool/versions.tf
+++ b/aks/terraform/modules/broker-node-pool/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "3.81.0"
+      version = "3.91.0"
     }
   }
 }

--- a/aks/terraform/modules/cluster/README.md
+++ b/aks/terraform/modules/cluster/README.md
@@ -61,5 +61,7 @@
 
 ## Outputs
 
-No outputs.
+| Name | Description |
+|------|-------------|
+| <a name="output_cluster_name"></a> [cluster\_name](#output\_cluster\_name) | n/a |
 <!-- END_TF_DOCS -->

--- a/aks/terraform/modules/cluster/README.md
+++ b/aks/terraform/modules/cluster/README.md
@@ -4,15 +4,15 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.3 |
-| <a name="requirement_azuread"></a> [azuread](#requirement\_azuread) | 2.46.0 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | 3.81.0 |
+| <a name="requirement_azuread"></a> [azuread](#requirement\_azuread) | 2.47.0 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | 3.91.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azuread"></a> [azuread](#provider\_azuread) | 2.46.0 |
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.81.0 |
+| <a name="provider_azuread"></a> [azuread](#provider\_azuread) | 2.47.0 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.91.0 |
 
 ## Modules
 
@@ -27,14 +27,14 @@
 
 | Name | Type |
 |------|------|
-| [azurerm_kubernetes_cluster.cluster](https://registry.terraform.io/providers/hashicorp/azurerm/3.81.0/docs/resources/kubernetes_cluster) | resource |
-| [azurerm_log_analytics_workspace.cluster](https://registry.terraform.io/providers/hashicorp/azurerm/3.81.0/docs/resources/log_analytics_workspace) | resource |
-| [azurerm_monitor_diagnostic_setting.cluster](https://registry.terraform.io/providers/hashicorp/azurerm/3.81.0/docs/resources/monitor_diagnostic_setting) | resource |
-| [azurerm_role_assignment.cluster_admin](https://registry.terraform.io/providers/hashicorp/azurerm/3.81.0/docs/resources/role_assignment) | resource |
-| [azurerm_role_assignment.cluster_route_table](https://registry.terraform.io/providers/hashicorp/azurerm/3.81.0/docs/resources/role_assignment) | resource |
-| [azurerm_role_assignment.cluster_subnet](https://registry.terraform.io/providers/hashicorp/azurerm/3.81.0/docs/resources/role_assignment) | resource |
-| [azurerm_user_assigned_identity.cluster](https://registry.terraform.io/providers/hashicorp/azurerm/3.81.0/docs/resources/user_assigned_identity) | resource |
-| [azuread_user.cluster_admin](https://registry.terraform.io/providers/hashicorp/azuread/2.46.0/docs/data-sources/user) | data source |
+| [azurerm_kubernetes_cluster.cluster](https://registry.terraform.io/providers/hashicorp/azurerm/3.91.0/docs/resources/kubernetes_cluster) | resource |
+| [azurerm_log_analytics_workspace.cluster](https://registry.terraform.io/providers/hashicorp/azurerm/3.91.0/docs/resources/log_analytics_workspace) | resource |
+| [azurerm_monitor_diagnostic_setting.cluster](https://registry.terraform.io/providers/hashicorp/azurerm/3.91.0/docs/resources/monitor_diagnostic_setting) | resource |
+| [azurerm_role_assignment.cluster_admin](https://registry.terraform.io/providers/hashicorp/azurerm/3.91.0/docs/resources/role_assignment) | resource |
+| [azurerm_role_assignment.cluster_route_table](https://registry.terraform.io/providers/hashicorp/azurerm/3.91.0/docs/resources/role_assignment) | resource |
+| [azurerm_role_assignment.cluster_subnet](https://registry.terraform.io/providers/hashicorp/azurerm/3.91.0/docs/resources/role_assignment) | resource |
+| [azurerm_user_assigned_identity.cluster](https://registry.terraform.io/providers/hashicorp/azurerm/3.91.0/docs/resources/user_assigned_identity) | resource |
+| [azuread_user.cluster_admin](https://registry.terraform.io/providers/hashicorp/azuread/2.47.0/docs/data-sources/user) | data source |
 
 ## Inputs
 

--- a/aks/terraform/modules/cluster/README.md
+++ b/aks/terraform/modules/cluster/README.md
@@ -5,14 +5,14 @@
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.3 |
 | <a name="requirement_azuread"></a> [azuread](#requirement\_azuread) | 2.47.0 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | 3.91.0 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | 3.94.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
 | <a name="provider_azuread"></a> [azuread](#provider\_azuread) | 2.47.0 |
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.91.0 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.94.0 |
 
 ## Modules
 
@@ -27,13 +27,13 @@
 
 | Name | Type |
 |------|------|
-| [azurerm_kubernetes_cluster.cluster](https://registry.terraform.io/providers/hashicorp/azurerm/3.91.0/docs/resources/kubernetes_cluster) | resource |
-| [azurerm_log_analytics_workspace.cluster](https://registry.terraform.io/providers/hashicorp/azurerm/3.91.0/docs/resources/log_analytics_workspace) | resource |
-| [azurerm_monitor_diagnostic_setting.cluster](https://registry.terraform.io/providers/hashicorp/azurerm/3.91.0/docs/resources/monitor_diagnostic_setting) | resource |
-| [azurerm_role_assignment.cluster_admin](https://registry.terraform.io/providers/hashicorp/azurerm/3.91.0/docs/resources/role_assignment) | resource |
-| [azurerm_role_assignment.cluster_route_table](https://registry.terraform.io/providers/hashicorp/azurerm/3.91.0/docs/resources/role_assignment) | resource |
-| [azurerm_role_assignment.cluster_subnet](https://registry.terraform.io/providers/hashicorp/azurerm/3.91.0/docs/resources/role_assignment) | resource |
-| [azurerm_user_assigned_identity.cluster](https://registry.terraform.io/providers/hashicorp/azurerm/3.91.0/docs/resources/user_assigned_identity) | resource |
+| [azurerm_kubernetes_cluster.cluster](https://registry.terraform.io/providers/hashicorp/azurerm/3.94.0/docs/resources/kubernetes_cluster) | resource |
+| [azurerm_log_analytics_workspace.cluster](https://registry.terraform.io/providers/hashicorp/azurerm/3.94.0/docs/resources/log_analytics_workspace) | resource |
+| [azurerm_monitor_diagnostic_setting.cluster](https://registry.terraform.io/providers/hashicorp/azurerm/3.94.0/docs/resources/monitor_diagnostic_setting) | resource |
+| [azurerm_role_assignment.cluster_admin](https://registry.terraform.io/providers/hashicorp/azurerm/3.94.0/docs/resources/role_assignment) | resource |
+| [azurerm_role_assignment.cluster_route_table](https://registry.terraform.io/providers/hashicorp/azurerm/3.94.0/docs/resources/role_assignment) | resource |
+| [azurerm_role_assignment.cluster_subnet](https://registry.terraform.io/providers/hashicorp/azurerm/3.94.0/docs/resources/role_assignment) | resource |
+| [azurerm_user_assigned_identity.cluster](https://registry.terraform.io/providers/hashicorp/azurerm/3.94.0/docs/resources/user_assigned_identity) | resource |
 | [azuread_user.cluster_admin](https://registry.terraform.io/providers/hashicorp/azuread/2.47.0/docs/data-sources/user) | data source |
 
 ## Inputs

--- a/aks/terraform/modules/cluster/outputs.tf
+++ b/aks/terraform/modules/cluster/outputs.tf
@@ -1,0 +1,3 @@
+output "cluster_name" {
+  value = azurerm_kubernetes_cluster.cluster.name
+}

--- a/aks/terraform/modules/cluster/versions.tf
+++ b/aks/terraform/modules/cluster/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "3.91.0"
+      version = "3.94.0"
     }
 
     azuread = {

--- a/aks/terraform/modules/cluster/versions.tf
+++ b/aks/terraform/modules/cluster/versions.tf
@@ -4,12 +4,12 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "3.81.0"
+      version = "3.91.0"
     }
 
     azuread = {
       source  = "hashicorp/azuread"
-      version = "2.46.0"
+      version = "2.47.0"
     }
   }
 }

--- a/aks/terraform/modules/network/README.md
+++ b/aks/terraform/modules/network/README.md
@@ -4,13 +4,13 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.3 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | 3.81.0 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | 3.91.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.81.0 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.91.0 |
 
 ## Modules
 
@@ -20,11 +20,11 @@ No modules.
 
 | Name | Type |
 |------|------|
-| [azurerm_route.cluster](https://registry.terraform.io/providers/hashicorp/azurerm/3.81.0/docs/resources/route) | resource |
-| [azurerm_route_table.cluster](https://registry.terraform.io/providers/hashicorp/azurerm/3.81.0/docs/resources/route_table) | resource |
-| [azurerm_subnet.cluster](https://registry.terraform.io/providers/hashicorp/azurerm/3.81.0/docs/resources/subnet) | resource |
-| [azurerm_subnet_route_table_association.cluster](https://registry.terraform.io/providers/hashicorp/azurerm/3.81.0/docs/resources/subnet_route_table_association) | resource |
-| [azurerm_virtual_network.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.81.0/docs/resources/virtual_network) | resource |
+| [azurerm_route.cluster](https://registry.terraform.io/providers/hashicorp/azurerm/3.91.0/docs/resources/route) | resource |
+| [azurerm_route_table.cluster](https://registry.terraform.io/providers/hashicorp/azurerm/3.91.0/docs/resources/route_table) | resource |
+| [azurerm_subnet.cluster](https://registry.terraform.io/providers/hashicorp/azurerm/3.91.0/docs/resources/subnet) | resource |
+| [azurerm_subnet_route_table_association.cluster](https://registry.terraform.io/providers/hashicorp/azurerm/3.91.0/docs/resources/subnet_route_table_association) | resource |
+| [azurerm_virtual_network.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.91.0/docs/resources/virtual_network) | resource |
 
 ## Inputs
 

--- a/aks/terraform/modules/network/README.md
+++ b/aks/terraform/modules/network/README.md
@@ -4,13 +4,13 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.3 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | 3.91.0 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | 3.94.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.91.0 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.94.0 |
 
 ## Modules
 
@@ -20,11 +20,11 @@ No modules.
 
 | Name | Type |
 |------|------|
-| [azurerm_route.cluster](https://registry.terraform.io/providers/hashicorp/azurerm/3.91.0/docs/resources/route) | resource |
-| [azurerm_route_table.cluster](https://registry.terraform.io/providers/hashicorp/azurerm/3.91.0/docs/resources/route_table) | resource |
-| [azurerm_subnet.cluster](https://registry.terraform.io/providers/hashicorp/azurerm/3.91.0/docs/resources/subnet) | resource |
-| [azurerm_subnet_route_table_association.cluster](https://registry.terraform.io/providers/hashicorp/azurerm/3.91.0/docs/resources/subnet_route_table_association) | resource |
-| [azurerm_virtual_network.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.91.0/docs/resources/virtual_network) | resource |
+| [azurerm_route.cluster](https://registry.terraform.io/providers/hashicorp/azurerm/3.94.0/docs/resources/route) | resource |
+| [azurerm_route_table.cluster](https://registry.terraform.io/providers/hashicorp/azurerm/3.94.0/docs/resources/route_table) | resource |
+| [azurerm_subnet.cluster](https://registry.terraform.io/providers/hashicorp/azurerm/3.94.0/docs/resources/subnet) | resource |
+| [azurerm_subnet_route_table_association.cluster](https://registry.terraform.io/providers/hashicorp/azurerm/3.94.0/docs/resources/subnet_route_table_association) | resource |
+| [azurerm_virtual_network.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.94.0/docs/resources/virtual_network) | resource |
 
 ## Inputs
 

--- a/aks/terraform/modules/network/versions.tf
+++ b/aks/terraform/modules/network/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "3.91.0"
+      version = "3.94.0"
     }
   }
 }

--- a/aks/terraform/modules/network/versions.tf
+++ b/aks/terraform/modules/network/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "3.81.0"
+      version = "3.91.0"
     }
   }
 }

--- a/eks/README.md
+++ b/eks/README.md
@@ -216,7 +216,7 @@ helm repo add autoscaler https://kubernetes.github.io/autoscaler
 helm repo update autoscaler
 
 terraform output -raw -state=terraform/terraform.tfstate cluster_autoscaler_helm_values | \
-    helm upgrade --install cluster-autoscaler autoscaler/cluster-autoscaler --version 9.29.0 -n kube-system --values - --set image.tag=<version>
+    helm upgrade --install cluster-autoscaler autoscaler/cluster-autoscaler --version 9.35.0 -n kube-system --values - --set image.tag=<version>
 ```
 
 ###  Deploying AWS Load Balancer Controller <a name="eks-deploy-lb"></a>
@@ -227,5 +227,5 @@ helm repo add eks https://aws.github.io/eks-charts
 helm repo update eks
 
 terraform output -raw -state=terraform/terraform.tfstate load_balancer_controller_helm_values | \
-    helm install aws-load-balancer-controller eks/aws-load-balancer-controller --version 1.5.3 -n kube-system --values -
+    helm install aws-load-balancer-controller eks/aws-load-balancer-controller --version 1.7.1 -n kube-system --values -
 ```

--- a/eks/terraform/modules/bastion/README.md
+++ b/eks/terraform/modules/bastion/README.md
@@ -4,13 +4,13 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.3 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | 5.26.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | 5.36.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.26.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.36.0 |
 
 ## Modules
 
@@ -20,18 +20,18 @@ No modules.
 
 | Name | Type |
 |------|------|
-| [aws_iam_instance_profile.bastion](https://registry.terraform.io/providers/hashicorp/aws/5.26.0/docs/resources/iam_instance_profile) | resource |
-| [aws_iam_role.bastion](https://registry.terraform.io/providers/hashicorp/aws/5.26.0/docs/resources/iam_role) | resource |
-| [aws_iam_role_policy_attachment.bastion_AmazonSSMManagedInstanceCore](https://registry.terraform.io/providers/hashicorp/aws/5.26.0/docs/resources/iam_role_policy_attachment) | resource |
-| [aws_instance.bastion](https://registry.terraform.io/providers/hashicorp/aws/5.26.0/docs/resources/instance) | resource |
-| [aws_key_pair.bastion](https://registry.terraform.io/providers/hashicorp/aws/5.26.0/docs/resources/key_pair) | resource |
-| [aws_security_group.bastion](https://registry.terraform.io/providers/hashicorp/aws/5.26.0/docs/resources/security_group) | resource |
-| [aws_security_group_rule.bastion_egress](https://registry.terraform.io/providers/hashicorp/aws/5.26.0/docs/resources/security_group_rule) | resource |
-| [aws_security_group_rule.bastion_ssh](https://registry.terraform.io/providers/hashicorp/aws/5.26.0/docs/resources/security_group_rule) | resource |
-| [aws_security_group_rule.cluster_from_bastion](https://registry.terraform.io/providers/hashicorp/aws/5.26.0/docs/resources/security_group_rule) | resource |
-| [aws_ami.amazon-linux](https://registry.terraform.io/providers/hashicorp/aws/5.26.0/docs/data-sources/ami) | data source |
-| [aws_iam_policy_document.bastion](https://registry.terraform.io/providers/hashicorp/aws/5.26.0/docs/data-sources/iam_policy_document) | data source |
-| [aws_partition.current](https://registry.terraform.io/providers/hashicorp/aws/5.26.0/docs/data-sources/partition) | data source |
+| [aws_iam_instance_profile.bastion](https://registry.terraform.io/providers/hashicorp/aws/5.36.0/docs/resources/iam_instance_profile) | resource |
+| [aws_iam_role.bastion](https://registry.terraform.io/providers/hashicorp/aws/5.36.0/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy_attachment.bastion_AmazonSSMManagedInstanceCore](https://registry.terraform.io/providers/hashicorp/aws/5.36.0/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_instance.bastion](https://registry.terraform.io/providers/hashicorp/aws/5.36.0/docs/resources/instance) | resource |
+| [aws_key_pair.bastion](https://registry.terraform.io/providers/hashicorp/aws/5.36.0/docs/resources/key_pair) | resource |
+| [aws_security_group.bastion](https://registry.terraform.io/providers/hashicorp/aws/5.36.0/docs/resources/security_group) | resource |
+| [aws_security_group_rule.bastion_egress](https://registry.terraform.io/providers/hashicorp/aws/5.36.0/docs/resources/security_group_rule) | resource |
+| [aws_security_group_rule.bastion_ssh](https://registry.terraform.io/providers/hashicorp/aws/5.36.0/docs/resources/security_group_rule) | resource |
+| [aws_security_group_rule.cluster_from_bastion](https://registry.terraform.io/providers/hashicorp/aws/5.36.0/docs/resources/security_group_rule) | resource |
+| [aws_ami.amazon-linux](https://registry.terraform.io/providers/hashicorp/aws/5.36.0/docs/data-sources/ami) | data source |
+| [aws_iam_policy_document.bastion](https://registry.terraform.io/providers/hashicorp/aws/5.36.0/docs/data-sources/iam_policy_document) | data source |
+| [aws_partition.current](https://registry.terraform.io/providers/hashicorp/aws/5.36.0/docs/data-sources/partition) | data source |
 
 ## Inputs
 

--- a/eks/terraform/modules/bastion/README.md
+++ b/eks/terraform/modules/bastion/README.md
@@ -4,13 +4,13 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.3 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | 5.36.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | 5.39.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.36.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.39.0 |
 
 ## Modules
 
@@ -20,18 +20,18 @@ No modules.
 
 | Name | Type |
 |------|------|
-| [aws_iam_instance_profile.bastion](https://registry.terraform.io/providers/hashicorp/aws/5.36.0/docs/resources/iam_instance_profile) | resource |
-| [aws_iam_role.bastion](https://registry.terraform.io/providers/hashicorp/aws/5.36.0/docs/resources/iam_role) | resource |
-| [aws_iam_role_policy_attachment.bastion_AmazonSSMManagedInstanceCore](https://registry.terraform.io/providers/hashicorp/aws/5.36.0/docs/resources/iam_role_policy_attachment) | resource |
-| [aws_instance.bastion](https://registry.terraform.io/providers/hashicorp/aws/5.36.0/docs/resources/instance) | resource |
-| [aws_key_pair.bastion](https://registry.terraform.io/providers/hashicorp/aws/5.36.0/docs/resources/key_pair) | resource |
-| [aws_security_group.bastion](https://registry.terraform.io/providers/hashicorp/aws/5.36.0/docs/resources/security_group) | resource |
-| [aws_security_group_rule.bastion_egress](https://registry.terraform.io/providers/hashicorp/aws/5.36.0/docs/resources/security_group_rule) | resource |
-| [aws_security_group_rule.bastion_ssh](https://registry.terraform.io/providers/hashicorp/aws/5.36.0/docs/resources/security_group_rule) | resource |
-| [aws_security_group_rule.cluster_from_bastion](https://registry.terraform.io/providers/hashicorp/aws/5.36.0/docs/resources/security_group_rule) | resource |
-| [aws_ami.amazon-linux](https://registry.terraform.io/providers/hashicorp/aws/5.36.0/docs/data-sources/ami) | data source |
-| [aws_iam_policy_document.bastion](https://registry.terraform.io/providers/hashicorp/aws/5.36.0/docs/data-sources/iam_policy_document) | data source |
-| [aws_partition.current](https://registry.terraform.io/providers/hashicorp/aws/5.36.0/docs/data-sources/partition) | data source |
+| [aws_iam_instance_profile.bastion](https://registry.terraform.io/providers/hashicorp/aws/5.39.0/docs/resources/iam_instance_profile) | resource |
+| [aws_iam_role.bastion](https://registry.terraform.io/providers/hashicorp/aws/5.39.0/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy_attachment.bastion_AmazonSSMManagedInstanceCore](https://registry.terraform.io/providers/hashicorp/aws/5.39.0/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_instance.bastion](https://registry.terraform.io/providers/hashicorp/aws/5.39.0/docs/resources/instance) | resource |
+| [aws_key_pair.bastion](https://registry.terraform.io/providers/hashicorp/aws/5.39.0/docs/resources/key_pair) | resource |
+| [aws_security_group.bastion](https://registry.terraform.io/providers/hashicorp/aws/5.39.0/docs/resources/security_group) | resource |
+| [aws_security_group_rule.bastion_egress](https://registry.terraform.io/providers/hashicorp/aws/5.39.0/docs/resources/security_group_rule) | resource |
+| [aws_security_group_rule.bastion_ssh](https://registry.terraform.io/providers/hashicorp/aws/5.39.0/docs/resources/security_group_rule) | resource |
+| [aws_security_group_rule.cluster_from_bastion](https://registry.terraform.io/providers/hashicorp/aws/5.39.0/docs/resources/security_group_rule) | resource |
+| [aws_ami.amazon-linux](https://registry.terraform.io/providers/hashicorp/aws/5.39.0/docs/data-sources/ami) | data source |
+| [aws_iam_policy_document.bastion](https://registry.terraform.io/providers/hashicorp/aws/5.39.0/docs/data-sources/iam_policy_document) | data source |
+| [aws_partition.current](https://registry.terraform.io/providers/hashicorp/aws/5.39.0/docs/data-sources/partition) | data source |
 
 ## Inputs
 

--- a/eks/terraform/modules/bastion/versions.tf
+++ b/eks/terraform/modules/bastion/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "5.36.0"
+      version = "5.39.0"
     }
   }
 }

--- a/eks/terraform/modules/bastion/versions.tf
+++ b/eks/terraform/modules/bastion/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "5.26.0"
+      version = "5.36.0"
     }
   }
 }

--- a/eks/terraform/modules/broker-node-group/README.md
+++ b/eks/terraform/modules/broker-node-group/README.md
@@ -4,13 +4,13 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.3 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | 5.26.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | 5.36.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.26.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.36.0 |
 
 ## Modules
 
@@ -20,12 +20,12 @@ No modules.
 
 | Name | Type |
 |------|------|
-| [aws_autoscaling_group_tag.labels_tags](https://registry.terraform.io/providers/hashicorp/aws/5.26.0/docs/resources/autoscaling_group_tag) | resource |
-| [aws_autoscaling_group_tag.name_tag](https://registry.terraform.io/providers/hashicorp/aws/5.26.0/docs/resources/autoscaling_group_tag) | resource |
-| [aws_autoscaling_group_tag.resources_tags](https://registry.terraform.io/providers/hashicorp/aws/5.26.0/docs/resources/autoscaling_group_tag) | resource |
-| [aws_autoscaling_group_tag.taints_tags](https://registry.terraform.io/providers/hashicorp/aws/5.26.0/docs/resources/autoscaling_group_tag) | resource |
-| [aws_eks_node_group.this](https://registry.terraform.io/providers/hashicorp/aws/5.26.0/docs/resources/eks_node_group) | resource |
-| [aws_launch_template.this](https://registry.terraform.io/providers/hashicorp/aws/5.26.0/docs/resources/launch_template) | resource |
+| [aws_autoscaling_group_tag.labels_tags](https://registry.terraform.io/providers/hashicorp/aws/5.36.0/docs/resources/autoscaling_group_tag) | resource |
+| [aws_autoscaling_group_tag.name_tag](https://registry.terraform.io/providers/hashicorp/aws/5.36.0/docs/resources/autoscaling_group_tag) | resource |
+| [aws_autoscaling_group_tag.resources_tags](https://registry.terraform.io/providers/hashicorp/aws/5.36.0/docs/resources/autoscaling_group_tag) | resource |
+| [aws_autoscaling_group_tag.taints_tags](https://registry.terraform.io/providers/hashicorp/aws/5.36.0/docs/resources/autoscaling_group_tag) | resource |
+| [aws_eks_node_group.this](https://registry.terraform.io/providers/hashicorp/aws/5.36.0/docs/resources/eks_node_group) | resource |
+| [aws_launch_template.this](https://registry.terraform.io/providers/hashicorp/aws/5.36.0/docs/resources/launch_template) | resource |
 
 ## Inputs
 

--- a/eks/terraform/modules/broker-node-group/README.md
+++ b/eks/terraform/modules/broker-node-group/README.md
@@ -4,13 +4,13 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.3 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | 5.36.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | 5.39.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.36.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.39.0 |
 
 ## Modules
 
@@ -20,12 +20,12 @@ No modules.
 
 | Name | Type |
 |------|------|
-| [aws_autoscaling_group_tag.labels_tags](https://registry.terraform.io/providers/hashicorp/aws/5.36.0/docs/resources/autoscaling_group_tag) | resource |
-| [aws_autoscaling_group_tag.name_tag](https://registry.terraform.io/providers/hashicorp/aws/5.36.0/docs/resources/autoscaling_group_tag) | resource |
-| [aws_autoscaling_group_tag.resources_tags](https://registry.terraform.io/providers/hashicorp/aws/5.36.0/docs/resources/autoscaling_group_tag) | resource |
-| [aws_autoscaling_group_tag.taints_tags](https://registry.terraform.io/providers/hashicorp/aws/5.36.0/docs/resources/autoscaling_group_tag) | resource |
-| [aws_eks_node_group.this](https://registry.terraform.io/providers/hashicorp/aws/5.36.0/docs/resources/eks_node_group) | resource |
-| [aws_launch_template.this](https://registry.terraform.io/providers/hashicorp/aws/5.36.0/docs/resources/launch_template) | resource |
+| [aws_autoscaling_group_tag.labels_tags](https://registry.terraform.io/providers/hashicorp/aws/5.39.0/docs/resources/autoscaling_group_tag) | resource |
+| [aws_autoscaling_group_tag.name_tag](https://registry.terraform.io/providers/hashicorp/aws/5.39.0/docs/resources/autoscaling_group_tag) | resource |
+| [aws_autoscaling_group_tag.resources_tags](https://registry.terraform.io/providers/hashicorp/aws/5.39.0/docs/resources/autoscaling_group_tag) | resource |
+| [aws_autoscaling_group_tag.taints_tags](https://registry.terraform.io/providers/hashicorp/aws/5.39.0/docs/resources/autoscaling_group_tag) | resource |
+| [aws_eks_node_group.this](https://registry.terraform.io/providers/hashicorp/aws/5.39.0/docs/resources/eks_node_group) | resource |
+| [aws_launch_template.this](https://registry.terraform.io/providers/hashicorp/aws/5.39.0/docs/resources/launch_template) | resource |
 
 ## Inputs
 

--- a/eks/terraform/modules/broker-node-group/versions.tf
+++ b/eks/terraform/modules/broker-node-group/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "5.36.0"
+      version = "5.39.0"
     }
   }
 }

--- a/eks/terraform/modules/broker-node-group/versions.tf
+++ b/eks/terraform/modules/broker-node-group/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "5.26.0"
+      version = "5.36.0"
     }
   }
 }

--- a/eks/terraform/modules/cluster/README.md
+++ b/eks/terraform/modules/cluster/README.md
@@ -4,62 +4,62 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.3 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | 5.26.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | 5.36.0 |
 | <a name="requirement_tls"></a> [tls](#requirement\_tls) | ~> 4.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.26.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.36.0 |
 | <a name="provider_tls"></a> [tls](#provider\_tls) | ~> 4.0 |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_cluster_autoscaler_irsa_role"></a> [cluster\_autoscaler\_irsa\_role](#module\_cluster\_autoscaler\_irsa\_role) | terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks | 5.30.0 |
-| <a name="module_ebs_csi_irsa_role"></a> [ebs\_csi\_irsa\_role](#module\_ebs\_csi\_irsa\_role) | terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks | 5.30.0 |
-| <a name="module_loadbalancer_controller_irsa_role"></a> [loadbalancer\_controller\_irsa\_role](#module\_loadbalancer\_controller\_irsa\_role) | terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks | 5.30.0 |
+| <a name="module_cluster_autoscaler_irsa_role"></a> [cluster\_autoscaler\_irsa\_role](#module\_cluster\_autoscaler\_irsa\_role) | terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks | 5.34.0 |
+| <a name="module_ebs_csi_irsa_role"></a> [ebs\_csi\_irsa\_role](#module\_ebs\_csi\_irsa\_role) | terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks | 5.34.0 |
+| <a name="module_loadbalancer_controller_irsa_role"></a> [loadbalancer\_controller\_irsa\_role](#module\_loadbalancer\_controller\_irsa\_role) | terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks | 5.34.0 |
 | <a name="module_node_group_monitoring"></a> [node\_group\_monitoring](#module\_node\_group\_monitoring) | ../broker-node-group | n/a |
 | <a name="module_node_group_prod100k"></a> [node\_group\_prod100k](#module\_node\_group\_prod100k) | ../broker-node-group | n/a |
 | <a name="module_node_group_prod10k"></a> [node\_group\_prod10k](#module\_node\_group\_prod10k) | ../broker-node-group | n/a |
 | <a name="module_node_group_prod1k"></a> [node\_group\_prod1k](#module\_node\_group\_prod1k) | ../broker-node-group | n/a |
-| <a name="module_vpc_cni_irsa_role"></a> [vpc\_cni\_irsa\_role](#module\_vpc\_cni\_irsa\_role) | terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks | 5.30.0 |
+| <a name="module_vpc_cni_irsa_role"></a> [vpc\_cni\_irsa\_role](#module\_vpc\_cni\_irsa\_role) | terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks | 5.34.0 |
 
 ## Resources
 
 | Name | Type |
 |------|------|
-| [aws_autoscaling_group_tag.default_name_tag](https://registry.terraform.io/providers/hashicorp/aws/5.26.0/docs/resources/autoscaling_group_tag) | resource |
-| [aws_cloudwatch_log_group.cluster_logs](https://registry.terraform.io/providers/hashicorp/aws/5.26.0/docs/resources/cloudwatch_log_group) | resource |
-| [aws_eks_addon.coredns](https://registry.terraform.io/providers/hashicorp/aws/5.26.0/docs/resources/eks_addon) | resource |
-| [aws_eks_addon.csi-driver](https://registry.terraform.io/providers/hashicorp/aws/5.26.0/docs/resources/eks_addon) | resource |
-| [aws_eks_addon.kube-proxy](https://registry.terraform.io/providers/hashicorp/aws/5.26.0/docs/resources/eks_addon) | resource |
-| [aws_eks_addon.vpc-cni](https://registry.terraform.io/providers/hashicorp/aws/5.26.0/docs/resources/eks_addon) | resource |
-| [aws_eks_cluster.cluster](https://registry.terraform.io/providers/hashicorp/aws/5.26.0/docs/resources/eks_cluster) | resource |
-| [aws_eks_node_group.default](https://registry.terraform.io/providers/hashicorp/aws/5.26.0/docs/resources/eks_node_group) | resource |
-| [aws_iam_openid_connect_provider.cluster](https://registry.terraform.io/providers/hashicorp/aws/5.26.0/docs/resources/iam_openid_connect_provider) | resource |
-| [aws_iam_role.cluster](https://registry.terraform.io/providers/hashicorp/aws/5.26.0/docs/resources/iam_role) | resource |
-| [aws_iam_role.worker_node](https://registry.terraform.io/providers/hashicorp/aws/5.26.0/docs/resources/iam_role) | resource |
-| [aws_iam_role_policy_attachment.cluster_AmazonEKSClusterPolicy](https://registry.terraform.io/providers/hashicorp/aws/5.26.0/docs/resources/iam_role_policy_attachment) | resource |
-| [aws_iam_role_policy_attachment.cluster_AmazonEKSServicePolicy](https://registry.terraform.io/providers/hashicorp/aws/5.26.0/docs/resources/iam_role_policy_attachment) | resource |
-| [aws_iam_role_policy_attachment.worker_node_AmazonEC2ContainerRegistryReadOnly](https://registry.terraform.io/providers/hashicorp/aws/5.26.0/docs/resources/iam_role_policy_attachment) | resource |
-| [aws_iam_role_policy_attachment.worker_node_AmazonEKSWorkerNodePolicy](https://registry.terraform.io/providers/hashicorp/aws/5.26.0/docs/resources/iam_role_policy_attachment) | resource |
-| [aws_iam_role_policy_attachment.worker_node_AmazonSSMManagedInstanceCore](https://registry.terraform.io/providers/hashicorp/aws/5.26.0/docs/resources/iam_role_policy_attachment) | resource |
-| [aws_kms_alias.logs](https://registry.terraform.io/providers/hashicorp/aws/5.26.0/docs/resources/kms_alias) | resource |
-| [aws_kms_alias.secrets](https://registry.terraform.io/providers/hashicorp/aws/5.26.0/docs/resources/kms_alias) | resource |
-| [aws_kms_key.logs](https://registry.terraform.io/providers/hashicorp/aws/5.26.0/docs/resources/kms_key) | resource |
-| [aws_kms_key.secrets](https://registry.terraform.io/providers/hashicorp/aws/5.26.0/docs/resources/kms_key) | resource |
-| [aws_kms_key_policy.logs](https://registry.terraform.io/providers/hashicorp/aws/5.26.0/docs/resources/kms_key_policy) | resource |
-| [aws_launch_template.default](https://registry.terraform.io/providers/hashicorp/aws/5.26.0/docs/resources/launch_template) | resource |
-| [aws_security_group.cluster](https://registry.terraform.io/providers/hashicorp/aws/5.26.0/docs/resources/security_group) | resource |
-| [aws_security_group.worker_node](https://registry.terraform.io/providers/hashicorp/aws/5.26.0/docs/resources/security_group) | resource |
-| [aws_security_group_rule.cluster_from_worker_node](https://registry.terraform.io/providers/hashicorp/aws/5.26.0/docs/resources/security_group_rule) | resource |
-| [aws_security_group_rule.worker_node_from_cluster](https://registry.terraform.io/providers/hashicorp/aws/5.26.0/docs/resources/security_group_rule) | resource |
-| [aws_security_group_rule.worker_node_to_worker_node](https://registry.terraform.io/providers/hashicorp/aws/5.26.0/docs/resources/security_group_rule) | resource |
-| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/5.26.0/docs/data-sources/caller_identity) | data source |
-| [aws_partition.current](https://registry.terraform.io/providers/hashicorp/aws/5.26.0/docs/data-sources/partition) | data source |
+| [aws_autoscaling_group_tag.default_name_tag](https://registry.terraform.io/providers/hashicorp/aws/5.36.0/docs/resources/autoscaling_group_tag) | resource |
+| [aws_cloudwatch_log_group.cluster_logs](https://registry.terraform.io/providers/hashicorp/aws/5.36.0/docs/resources/cloudwatch_log_group) | resource |
+| [aws_eks_addon.coredns](https://registry.terraform.io/providers/hashicorp/aws/5.36.0/docs/resources/eks_addon) | resource |
+| [aws_eks_addon.csi-driver](https://registry.terraform.io/providers/hashicorp/aws/5.36.0/docs/resources/eks_addon) | resource |
+| [aws_eks_addon.kube-proxy](https://registry.terraform.io/providers/hashicorp/aws/5.36.0/docs/resources/eks_addon) | resource |
+| [aws_eks_addon.vpc-cni](https://registry.terraform.io/providers/hashicorp/aws/5.36.0/docs/resources/eks_addon) | resource |
+| [aws_eks_cluster.cluster](https://registry.terraform.io/providers/hashicorp/aws/5.36.0/docs/resources/eks_cluster) | resource |
+| [aws_eks_node_group.default](https://registry.terraform.io/providers/hashicorp/aws/5.36.0/docs/resources/eks_node_group) | resource |
+| [aws_iam_openid_connect_provider.cluster](https://registry.terraform.io/providers/hashicorp/aws/5.36.0/docs/resources/iam_openid_connect_provider) | resource |
+| [aws_iam_role.cluster](https://registry.terraform.io/providers/hashicorp/aws/5.36.0/docs/resources/iam_role) | resource |
+| [aws_iam_role.worker_node](https://registry.terraform.io/providers/hashicorp/aws/5.36.0/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy_attachment.cluster_AmazonEKSClusterPolicy](https://registry.terraform.io/providers/hashicorp/aws/5.36.0/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.cluster_AmazonEKSServicePolicy](https://registry.terraform.io/providers/hashicorp/aws/5.36.0/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.worker_node_AmazonEC2ContainerRegistryReadOnly](https://registry.terraform.io/providers/hashicorp/aws/5.36.0/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.worker_node_AmazonEKSWorkerNodePolicy](https://registry.terraform.io/providers/hashicorp/aws/5.36.0/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.worker_node_AmazonSSMManagedInstanceCore](https://registry.terraform.io/providers/hashicorp/aws/5.36.0/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_kms_alias.logs](https://registry.terraform.io/providers/hashicorp/aws/5.36.0/docs/resources/kms_alias) | resource |
+| [aws_kms_alias.secrets](https://registry.terraform.io/providers/hashicorp/aws/5.36.0/docs/resources/kms_alias) | resource |
+| [aws_kms_key.logs](https://registry.terraform.io/providers/hashicorp/aws/5.36.0/docs/resources/kms_key) | resource |
+| [aws_kms_key.secrets](https://registry.terraform.io/providers/hashicorp/aws/5.36.0/docs/resources/kms_key) | resource |
+| [aws_kms_key_policy.logs](https://registry.terraform.io/providers/hashicorp/aws/5.36.0/docs/resources/kms_key_policy) | resource |
+| [aws_launch_template.default](https://registry.terraform.io/providers/hashicorp/aws/5.36.0/docs/resources/launch_template) | resource |
+| [aws_security_group.cluster](https://registry.terraform.io/providers/hashicorp/aws/5.36.0/docs/resources/security_group) | resource |
+| [aws_security_group.worker_node](https://registry.terraform.io/providers/hashicorp/aws/5.36.0/docs/resources/security_group) | resource |
+| [aws_security_group_rule.cluster_from_worker_node](https://registry.terraform.io/providers/hashicorp/aws/5.36.0/docs/resources/security_group_rule) | resource |
+| [aws_security_group_rule.worker_node_from_cluster](https://registry.terraform.io/providers/hashicorp/aws/5.36.0/docs/resources/security_group_rule) | resource |
+| [aws_security_group_rule.worker_node_to_worker_node](https://registry.terraform.io/providers/hashicorp/aws/5.36.0/docs/resources/security_group_rule) | resource |
+| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/5.36.0/docs/data-sources/caller_identity) | data source |
+| [aws_partition.current](https://registry.terraform.io/providers/hashicorp/aws/5.36.0/docs/data-sources/partition) | data source |
 | [tls_certificate.eks_oidc_issuer](https://registry.terraform.io/providers/hashicorp/tls/latest/docs/data-sources/certificate) | data source |
 
 ## Inputs

--- a/eks/terraform/modules/cluster/README.md
+++ b/eks/terraform/modules/cluster/README.md
@@ -81,7 +81,9 @@
 | Name | Description |
 |------|-------------|
 | <a name="output_cluster_autoscaler_helm_values"></a> [cluster\_autoscaler\_helm\_values](#output\_cluster\_autoscaler\_helm\_values) | n/a |
+| <a name="output_cluster_name"></a> [cluster\_name](#output\_cluster\_name) | n/a |
 | <a name="output_cluster_security_group_id"></a> [cluster\_security\_group\_id](#output\_cluster\_security\_group\_id) | n/a |
+| <a name="output_default_node_group_arn"></a> [default\_node\_group\_arn](#output\_default\_node\_group\_arn) | n/a |
 | <a name="output_load_balancer_controller_helm_values"></a> [load\_balancer\_controller\_helm\_values](#output\_load\_balancer\_controller\_helm\_values) | n/a |
 | <a name="output_worker_node_role_arn"></a> [worker\_node\_role\_arn](#output\_worker\_node\_role\_arn) | n/a |
 <!-- END_TF_DOCS -->

--- a/eks/terraform/modules/cluster/README.md
+++ b/eks/terraform/modules/cluster/README.md
@@ -4,14 +4,14 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.3 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | 5.36.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | 5.39.0 |
 | <a name="requirement_tls"></a> [tls](#requirement\_tls) | ~> 4.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.36.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.39.0 |
 | <a name="provider_tls"></a> [tls](#provider\_tls) | ~> 4.0 |
 
 ## Modules
@@ -31,35 +31,35 @@
 
 | Name | Type |
 |------|------|
-| [aws_autoscaling_group_tag.default_name_tag](https://registry.terraform.io/providers/hashicorp/aws/5.36.0/docs/resources/autoscaling_group_tag) | resource |
-| [aws_cloudwatch_log_group.cluster_logs](https://registry.terraform.io/providers/hashicorp/aws/5.36.0/docs/resources/cloudwatch_log_group) | resource |
-| [aws_eks_addon.coredns](https://registry.terraform.io/providers/hashicorp/aws/5.36.0/docs/resources/eks_addon) | resource |
-| [aws_eks_addon.csi-driver](https://registry.terraform.io/providers/hashicorp/aws/5.36.0/docs/resources/eks_addon) | resource |
-| [aws_eks_addon.kube-proxy](https://registry.terraform.io/providers/hashicorp/aws/5.36.0/docs/resources/eks_addon) | resource |
-| [aws_eks_addon.vpc-cni](https://registry.terraform.io/providers/hashicorp/aws/5.36.0/docs/resources/eks_addon) | resource |
-| [aws_eks_cluster.cluster](https://registry.terraform.io/providers/hashicorp/aws/5.36.0/docs/resources/eks_cluster) | resource |
-| [aws_eks_node_group.default](https://registry.terraform.io/providers/hashicorp/aws/5.36.0/docs/resources/eks_node_group) | resource |
-| [aws_iam_openid_connect_provider.cluster](https://registry.terraform.io/providers/hashicorp/aws/5.36.0/docs/resources/iam_openid_connect_provider) | resource |
-| [aws_iam_role.cluster](https://registry.terraform.io/providers/hashicorp/aws/5.36.0/docs/resources/iam_role) | resource |
-| [aws_iam_role.worker_node](https://registry.terraform.io/providers/hashicorp/aws/5.36.0/docs/resources/iam_role) | resource |
-| [aws_iam_role_policy_attachment.cluster_AmazonEKSClusterPolicy](https://registry.terraform.io/providers/hashicorp/aws/5.36.0/docs/resources/iam_role_policy_attachment) | resource |
-| [aws_iam_role_policy_attachment.cluster_AmazonEKSServicePolicy](https://registry.terraform.io/providers/hashicorp/aws/5.36.0/docs/resources/iam_role_policy_attachment) | resource |
-| [aws_iam_role_policy_attachment.worker_node_AmazonEC2ContainerRegistryReadOnly](https://registry.terraform.io/providers/hashicorp/aws/5.36.0/docs/resources/iam_role_policy_attachment) | resource |
-| [aws_iam_role_policy_attachment.worker_node_AmazonEKSWorkerNodePolicy](https://registry.terraform.io/providers/hashicorp/aws/5.36.0/docs/resources/iam_role_policy_attachment) | resource |
-| [aws_iam_role_policy_attachment.worker_node_AmazonSSMManagedInstanceCore](https://registry.terraform.io/providers/hashicorp/aws/5.36.0/docs/resources/iam_role_policy_attachment) | resource |
-| [aws_kms_alias.logs](https://registry.terraform.io/providers/hashicorp/aws/5.36.0/docs/resources/kms_alias) | resource |
-| [aws_kms_alias.secrets](https://registry.terraform.io/providers/hashicorp/aws/5.36.0/docs/resources/kms_alias) | resource |
-| [aws_kms_key.logs](https://registry.terraform.io/providers/hashicorp/aws/5.36.0/docs/resources/kms_key) | resource |
-| [aws_kms_key.secrets](https://registry.terraform.io/providers/hashicorp/aws/5.36.0/docs/resources/kms_key) | resource |
-| [aws_kms_key_policy.logs](https://registry.terraform.io/providers/hashicorp/aws/5.36.0/docs/resources/kms_key_policy) | resource |
-| [aws_launch_template.default](https://registry.terraform.io/providers/hashicorp/aws/5.36.0/docs/resources/launch_template) | resource |
-| [aws_security_group.cluster](https://registry.terraform.io/providers/hashicorp/aws/5.36.0/docs/resources/security_group) | resource |
-| [aws_security_group.worker_node](https://registry.terraform.io/providers/hashicorp/aws/5.36.0/docs/resources/security_group) | resource |
-| [aws_security_group_rule.cluster_from_worker_node](https://registry.terraform.io/providers/hashicorp/aws/5.36.0/docs/resources/security_group_rule) | resource |
-| [aws_security_group_rule.worker_node_from_cluster](https://registry.terraform.io/providers/hashicorp/aws/5.36.0/docs/resources/security_group_rule) | resource |
-| [aws_security_group_rule.worker_node_to_worker_node](https://registry.terraform.io/providers/hashicorp/aws/5.36.0/docs/resources/security_group_rule) | resource |
-| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/5.36.0/docs/data-sources/caller_identity) | data source |
-| [aws_partition.current](https://registry.terraform.io/providers/hashicorp/aws/5.36.0/docs/data-sources/partition) | data source |
+| [aws_autoscaling_group_tag.default_name_tag](https://registry.terraform.io/providers/hashicorp/aws/5.39.0/docs/resources/autoscaling_group_tag) | resource |
+| [aws_cloudwatch_log_group.cluster_logs](https://registry.terraform.io/providers/hashicorp/aws/5.39.0/docs/resources/cloudwatch_log_group) | resource |
+| [aws_eks_addon.coredns](https://registry.terraform.io/providers/hashicorp/aws/5.39.0/docs/resources/eks_addon) | resource |
+| [aws_eks_addon.csi-driver](https://registry.terraform.io/providers/hashicorp/aws/5.39.0/docs/resources/eks_addon) | resource |
+| [aws_eks_addon.kube-proxy](https://registry.terraform.io/providers/hashicorp/aws/5.39.0/docs/resources/eks_addon) | resource |
+| [aws_eks_addon.vpc-cni](https://registry.terraform.io/providers/hashicorp/aws/5.39.0/docs/resources/eks_addon) | resource |
+| [aws_eks_cluster.cluster](https://registry.terraform.io/providers/hashicorp/aws/5.39.0/docs/resources/eks_cluster) | resource |
+| [aws_eks_node_group.default](https://registry.terraform.io/providers/hashicorp/aws/5.39.0/docs/resources/eks_node_group) | resource |
+| [aws_iam_openid_connect_provider.cluster](https://registry.terraform.io/providers/hashicorp/aws/5.39.0/docs/resources/iam_openid_connect_provider) | resource |
+| [aws_iam_role.cluster](https://registry.terraform.io/providers/hashicorp/aws/5.39.0/docs/resources/iam_role) | resource |
+| [aws_iam_role.worker_node](https://registry.terraform.io/providers/hashicorp/aws/5.39.0/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy_attachment.cluster_AmazonEKSClusterPolicy](https://registry.terraform.io/providers/hashicorp/aws/5.39.0/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.cluster_AmazonEKSServicePolicy](https://registry.terraform.io/providers/hashicorp/aws/5.39.0/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.worker_node_AmazonEC2ContainerRegistryReadOnly](https://registry.terraform.io/providers/hashicorp/aws/5.39.0/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.worker_node_AmazonEKSWorkerNodePolicy](https://registry.terraform.io/providers/hashicorp/aws/5.39.0/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.worker_node_AmazonSSMManagedInstanceCore](https://registry.terraform.io/providers/hashicorp/aws/5.39.0/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_kms_alias.logs](https://registry.terraform.io/providers/hashicorp/aws/5.39.0/docs/resources/kms_alias) | resource |
+| [aws_kms_alias.secrets](https://registry.terraform.io/providers/hashicorp/aws/5.39.0/docs/resources/kms_alias) | resource |
+| [aws_kms_key.logs](https://registry.terraform.io/providers/hashicorp/aws/5.39.0/docs/resources/kms_key) | resource |
+| [aws_kms_key.secrets](https://registry.terraform.io/providers/hashicorp/aws/5.39.0/docs/resources/kms_key) | resource |
+| [aws_kms_key_policy.logs](https://registry.terraform.io/providers/hashicorp/aws/5.39.0/docs/resources/kms_key_policy) | resource |
+| [aws_launch_template.default](https://registry.terraform.io/providers/hashicorp/aws/5.39.0/docs/resources/launch_template) | resource |
+| [aws_security_group.cluster](https://registry.terraform.io/providers/hashicorp/aws/5.39.0/docs/resources/security_group) | resource |
+| [aws_security_group.worker_node](https://registry.terraform.io/providers/hashicorp/aws/5.39.0/docs/resources/security_group) | resource |
+| [aws_security_group_rule.cluster_from_worker_node](https://registry.terraform.io/providers/hashicorp/aws/5.39.0/docs/resources/security_group_rule) | resource |
+| [aws_security_group_rule.worker_node_from_cluster](https://registry.terraform.io/providers/hashicorp/aws/5.39.0/docs/resources/security_group_rule) | resource |
+| [aws_security_group_rule.worker_node_to_worker_node](https://registry.terraform.io/providers/hashicorp/aws/5.39.0/docs/resources/security_group_rule) | resource |
+| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/5.39.0/docs/data-sources/caller_identity) | data source |
+| [aws_partition.current](https://registry.terraform.io/providers/hashicorp/aws/5.39.0/docs/data-sources/partition) | data source |
 | [tls_certificate.eks_oidc_issuer](https://registry.terraform.io/providers/hashicorp/tls/latest/docs/data-sources/certificate) | data source |
 
 ## Inputs

--- a/eks/terraform/modules/cluster/main.tf
+++ b/eks/terraform/modules/cluster/main.tf
@@ -21,7 +21,7 @@ data "aws_caller_identity" "current" {}
 
 module "cluster_autoscaler_irsa_role" {
   source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
-  version = "5.30.0"
+  version = "5.34.0"
 
   role_name          = "${var.cluster_name}-cluster-autoscaler"
   policy_name_prefix = "${var.cluster_name}-"
@@ -39,7 +39,7 @@ module "cluster_autoscaler_irsa_role" {
 
 module "loadbalancer_controller_irsa_role" {
   source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
-  version = "5.30.0"
+  version = "5.34.0"
 
   role_name          = "${var.cluster_name}-loadbalancer-controller"
   policy_name_prefix = "${var.cluster_name}-"
@@ -56,7 +56,7 @@ module "loadbalancer_controller_irsa_role" {
 
 module "ebs_csi_irsa_role" {
   source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
-  version = "5.30.0"
+  version = "5.34.0"
 
   role_name          = "${var.cluster_name}-ebs-csi"
   policy_name_prefix = "${var.cluster_name}-"
@@ -73,7 +73,7 @@ module "ebs_csi_irsa_role" {
 
 module "vpc_cni_irsa_role" {
   source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
-  version = "5.30.0"
+  version = "5.34.0"
 
   role_name          = "${var.cluster_name}-vpc-cni"
   policy_name_prefix = "${var.cluster_name}-"

--- a/eks/terraform/modules/cluster/outputs.tf
+++ b/eks/terraform/modules/cluster/outputs.tf
@@ -1,3 +1,11 @@
+output "cluster_name" {
+  value = aws_eks_cluster.cluster.name
+}
+
+output "default_node_group_arn" {
+  value = aws_eks_node_group.default.arn
+}
+
 output "cluster_security_group_id" {
   value = aws_security_group.cluster.id
 }

--- a/eks/terraform/modules/cluster/versions.tf
+++ b/eks/terraform/modules/cluster/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "5.26.0"
+      version = "5.36.0"
     }
 
     tls = {

--- a/eks/terraform/modules/cluster/versions.tf
+++ b/eks/terraform/modules/cluster/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "5.36.0"
+      version = "5.39.0"
     }
 
     tls = {

--- a/eks/terraform/modules/network/README.md
+++ b/eks/terraform/modules/network/README.md
@@ -4,13 +4,13 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.3 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | 5.26.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | 5.36.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.26.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.36.0 |
 
 ## Modules
 
@@ -20,17 +20,17 @@ No modules.
 
 | Name | Type |
 |------|------|
-| [aws_eip.nat](https://registry.terraform.io/providers/hashicorp/aws/5.26.0/docs/resources/eip) | resource |
-| [aws_internet_gateway.gateway](https://registry.terraform.io/providers/hashicorp/aws/5.26.0/docs/resources/internet_gateway) | resource |
-| [aws_nat_gateway.nat](https://registry.terraform.io/providers/hashicorp/aws/5.26.0/docs/resources/nat_gateway) | resource |
-| [aws_route_table.private](https://registry.terraform.io/providers/hashicorp/aws/5.26.0/docs/resources/route_table) | resource |
-| [aws_route_table.public](https://registry.terraform.io/providers/hashicorp/aws/5.26.0/docs/resources/route_table) | resource |
-| [aws_route_table_association.private](https://registry.terraform.io/providers/hashicorp/aws/5.26.0/docs/resources/route_table_association) | resource |
-| [aws_route_table_association.public](https://registry.terraform.io/providers/hashicorp/aws/5.26.0/docs/resources/route_table_association) | resource |
-| [aws_subnet.private](https://registry.terraform.io/providers/hashicorp/aws/5.26.0/docs/resources/subnet) | resource |
-| [aws_subnet.public](https://registry.terraform.io/providers/hashicorp/aws/5.26.0/docs/resources/subnet) | resource |
-| [aws_vpc.this](https://registry.terraform.io/providers/hashicorp/aws/5.26.0/docs/resources/vpc) | resource |
-| [aws_availability_zones.available](https://registry.terraform.io/providers/hashicorp/aws/5.26.0/docs/data-sources/availability_zones) | data source |
+| [aws_eip.nat](https://registry.terraform.io/providers/hashicorp/aws/5.36.0/docs/resources/eip) | resource |
+| [aws_internet_gateway.gateway](https://registry.terraform.io/providers/hashicorp/aws/5.36.0/docs/resources/internet_gateway) | resource |
+| [aws_nat_gateway.nat](https://registry.terraform.io/providers/hashicorp/aws/5.36.0/docs/resources/nat_gateway) | resource |
+| [aws_route_table.private](https://registry.terraform.io/providers/hashicorp/aws/5.36.0/docs/resources/route_table) | resource |
+| [aws_route_table.public](https://registry.terraform.io/providers/hashicorp/aws/5.36.0/docs/resources/route_table) | resource |
+| [aws_route_table_association.private](https://registry.terraform.io/providers/hashicorp/aws/5.36.0/docs/resources/route_table_association) | resource |
+| [aws_route_table_association.public](https://registry.terraform.io/providers/hashicorp/aws/5.36.0/docs/resources/route_table_association) | resource |
+| [aws_subnet.private](https://registry.terraform.io/providers/hashicorp/aws/5.36.0/docs/resources/subnet) | resource |
+| [aws_subnet.public](https://registry.terraform.io/providers/hashicorp/aws/5.36.0/docs/resources/subnet) | resource |
+| [aws_vpc.this](https://registry.terraform.io/providers/hashicorp/aws/5.36.0/docs/resources/vpc) | resource |
+| [aws_availability_zones.available](https://registry.terraform.io/providers/hashicorp/aws/5.36.0/docs/data-sources/availability_zones) | data source |
 
 ## Inputs
 

--- a/eks/terraform/modules/network/README.md
+++ b/eks/terraform/modules/network/README.md
@@ -4,13 +4,13 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.3 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | 5.36.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | 5.39.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.36.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.39.0 |
 
 ## Modules
 
@@ -20,17 +20,17 @@ No modules.
 
 | Name | Type |
 |------|------|
-| [aws_eip.nat](https://registry.terraform.io/providers/hashicorp/aws/5.36.0/docs/resources/eip) | resource |
-| [aws_internet_gateway.gateway](https://registry.terraform.io/providers/hashicorp/aws/5.36.0/docs/resources/internet_gateway) | resource |
-| [aws_nat_gateway.nat](https://registry.terraform.io/providers/hashicorp/aws/5.36.0/docs/resources/nat_gateway) | resource |
-| [aws_route_table.private](https://registry.terraform.io/providers/hashicorp/aws/5.36.0/docs/resources/route_table) | resource |
-| [aws_route_table.public](https://registry.terraform.io/providers/hashicorp/aws/5.36.0/docs/resources/route_table) | resource |
-| [aws_route_table_association.private](https://registry.terraform.io/providers/hashicorp/aws/5.36.0/docs/resources/route_table_association) | resource |
-| [aws_route_table_association.public](https://registry.terraform.io/providers/hashicorp/aws/5.36.0/docs/resources/route_table_association) | resource |
-| [aws_subnet.private](https://registry.terraform.io/providers/hashicorp/aws/5.36.0/docs/resources/subnet) | resource |
-| [aws_subnet.public](https://registry.terraform.io/providers/hashicorp/aws/5.36.0/docs/resources/subnet) | resource |
-| [aws_vpc.this](https://registry.terraform.io/providers/hashicorp/aws/5.36.0/docs/resources/vpc) | resource |
-| [aws_availability_zones.available](https://registry.terraform.io/providers/hashicorp/aws/5.36.0/docs/data-sources/availability_zones) | data source |
+| [aws_eip.nat](https://registry.terraform.io/providers/hashicorp/aws/5.39.0/docs/resources/eip) | resource |
+| [aws_internet_gateway.gateway](https://registry.terraform.io/providers/hashicorp/aws/5.39.0/docs/resources/internet_gateway) | resource |
+| [aws_nat_gateway.nat](https://registry.terraform.io/providers/hashicorp/aws/5.39.0/docs/resources/nat_gateway) | resource |
+| [aws_route_table.private](https://registry.terraform.io/providers/hashicorp/aws/5.39.0/docs/resources/route_table) | resource |
+| [aws_route_table.public](https://registry.terraform.io/providers/hashicorp/aws/5.39.0/docs/resources/route_table) | resource |
+| [aws_route_table_association.private](https://registry.terraform.io/providers/hashicorp/aws/5.39.0/docs/resources/route_table_association) | resource |
+| [aws_route_table_association.public](https://registry.terraform.io/providers/hashicorp/aws/5.39.0/docs/resources/route_table_association) | resource |
+| [aws_subnet.private](https://registry.terraform.io/providers/hashicorp/aws/5.39.0/docs/resources/subnet) | resource |
+| [aws_subnet.public](https://registry.terraform.io/providers/hashicorp/aws/5.39.0/docs/resources/subnet) | resource |
+| [aws_vpc.this](https://registry.terraform.io/providers/hashicorp/aws/5.39.0/docs/resources/vpc) | resource |
+| [aws_availability_zones.available](https://registry.terraform.io/providers/hashicorp/aws/5.39.0/docs/data-sources/availability_zones) | data source |
 
 ## Inputs
 

--- a/eks/terraform/modules/network/versions.tf
+++ b/eks/terraform/modules/network/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "5.36.0"
+      version = "5.39.0"
     }
   }
 }

--- a/eks/terraform/modules/network/versions.tf
+++ b/eks/terraform/modules/network/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "5.26.0"
+      version = "5.36.0"
     }
   }
 }

--- a/gke/terraform/modules/bastion/README.md
+++ b/gke/terraform/modules/bastion/README.md
@@ -4,13 +4,13 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.3 |
-| <a name="requirement_google"></a> [google](#requirement\_google) | 5.6.0 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | 5.15.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_google"></a> [google](#provider\_google) | 5.6.0 |
+| <a name="provider_google"></a> [google](#provider\_google) | 5.15.0 |
 
 ## Modules
 
@@ -20,10 +20,10 @@ No modules.
 
 | Name | Type |
 |------|------|
-| [google_compute_firewall.bastion](https://registry.terraform.io/providers/hashicorp/google/5.6.0/docs/resources/compute_firewall) | resource |
-| [google_compute_instance.bastion](https://registry.terraform.io/providers/hashicorp/google/5.6.0/docs/resources/compute_instance) | resource |
-| [google_service_account.bastion](https://registry.terraform.io/providers/hashicorp/google/5.6.0/docs/resources/service_account) | resource |
-| [google_compute_zones.available](https://registry.terraform.io/providers/hashicorp/google/5.6.0/docs/data-sources/compute_zones) | data source |
+| [google_compute_firewall.bastion](https://registry.terraform.io/providers/hashicorp/google/5.15.0/docs/resources/compute_firewall) | resource |
+| [google_compute_instance.bastion](https://registry.terraform.io/providers/hashicorp/google/5.15.0/docs/resources/compute_instance) | resource |
+| [google_service_account.bastion](https://registry.terraform.io/providers/hashicorp/google/5.15.0/docs/resources/service_account) | resource |
+| [google_compute_zones.available](https://registry.terraform.io/providers/hashicorp/google/5.15.0/docs/data-sources/compute_zones) | data source |
 
 ## Inputs
 

--- a/gke/terraform/modules/bastion/README.md
+++ b/gke/terraform/modules/bastion/README.md
@@ -4,13 +4,13 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.3 |
-| <a name="requirement_google"></a> [google](#requirement\_google) | 5.15.0 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | 5.18.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_google"></a> [google](#provider\_google) | 5.15.0 |
+| <a name="provider_google"></a> [google](#provider\_google) | 5.18.0 |
 
 ## Modules
 
@@ -20,10 +20,10 @@ No modules.
 
 | Name | Type |
 |------|------|
-| [google_compute_firewall.bastion](https://registry.terraform.io/providers/hashicorp/google/5.15.0/docs/resources/compute_firewall) | resource |
-| [google_compute_instance.bastion](https://registry.terraform.io/providers/hashicorp/google/5.15.0/docs/resources/compute_instance) | resource |
-| [google_service_account.bastion](https://registry.terraform.io/providers/hashicorp/google/5.15.0/docs/resources/service_account) | resource |
-| [google_compute_zones.available](https://registry.terraform.io/providers/hashicorp/google/5.15.0/docs/data-sources/compute_zones) | data source |
+| [google_compute_firewall.bastion](https://registry.terraform.io/providers/hashicorp/google/5.18.0/docs/resources/compute_firewall) | resource |
+| [google_compute_instance.bastion](https://registry.terraform.io/providers/hashicorp/google/5.18.0/docs/resources/compute_instance) | resource |
+| [google_service_account.bastion](https://registry.terraform.io/providers/hashicorp/google/5.18.0/docs/resources/service_account) | resource |
+| [google_compute_zones.available](https://registry.terraform.io/providers/hashicorp/google/5.18.0/docs/data-sources/compute_zones) | data source |
 
 ## Inputs
 

--- a/gke/terraform/modules/bastion/versions.tf
+++ b/gke/terraform/modules/bastion/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "5.15.0"
+      version = "5.18.0"
     }
   }
 }

--- a/gke/terraform/modules/bastion/versions.tf
+++ b/gke/terraform/modules/bastion/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "5.6.0"
+      version = "5.15.0"
     }
   }
 }

--- a/gke/terraform/modules/broker-node-pool/README.md
+++ b/gke/terraform/modules/broker-node-pool/README.md
@@ -4,13 +4,13 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.3 |
-| <a name="requirement_google"></a> [google](#requirement\_google) | 5.15.0 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | 5.18.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_google"></a> [google](#provider\_google) | 5.15.0 |
+| <a name="provider_google"></a> [google](#provider\_google) | 5.18.0 |
 
 ## Modules
 
@@ -20,7 +20,7 @@ No modules.
 
 | Name | Type |
 |------|------|
-| [google_container_node_pool.this](https://registry.terraform.io/providers/hashicorp/google/5.15.0/docs/resources/container_node_pool) | resource |
+| [google_container_node_pool.this](https://registry.terraform.io/providers/hashicorp/google/5.18.0/docs/resources/container_node_pool) | resource |
 
 ## Inputs
 

--- a/gke/terraform/modules/broker-node-pool/README.md
+++ b/gke/terraform/modules/broker-node-pool/README.md
@@ -4,13 +4,13 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.3 |
-| <a name="requirement_google"></a> [google](#requirement\_google) | 5.6.0 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | 5.15.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_google"></a> [google](#provider\_google) | 5.6.0 |
+| <a name="provider_google"></a> [google](#provider\_google) | 5.15.0 |
 
 ## Modules
 
@@ -20,7 +20,7 @@ No modules.
 
 | Name | Type |
 |------|------|
-| [google_container_node_pool.this](https://registry.terraform.io/providers/hashicorp/google/5.6.0/docs/resources/container_node_pool) | resource |
+| [google_container_node_pool.this](https://registry.terraform.io/providers/hashicorp/google/5.15.0/docs/resources/container_node_pool) | resource |
 
 ## Inputs
 

--- a/gke/terraform/modules/broker-node-pool/versions.tf
+++ b/gke/terraform/modules/broker-node-pool/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "5.15.0"
+      version = "5.18.0"
     }
   }
 }

--- a/gke/terraform/modules/broker-node-pool/versions.tf
+++ b/gke/terraform/modules/broker-node-pool/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "5.6.0"
+      version = "5.15.0"
     }
   }
 }

--- a/gke/terraform/modules/cluster/README.md
+++ b/gke/terraform/modules/cluster/README.md
@@ -4,13 +4,13 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.3 |
-| <a name="requirement_google"></a> [google](#requirement\_google) | 5.6.0 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | 5.15.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_google"></a> [google](#provider\_google) | 5.6.0 |
+| <a name="provider_google"></a> [google](#provider\_google) | 5.15.0 |
 
 ## Modules
 
@@ -25,11 +25,11 @@
 
 | Name | Type |
 |------|------|
-| [google_container_cluster.cluster](https://registry.terraform.io/providers/hashicorp/google/5.6.0/docs/resources/container_cluster) | resource |
-| [google_container_node_pool.system](https://registry.terraform.io/providers/hashicorp/google/5.6.0/docs/resources/container_node_pool) | resource |
-| [google_service_account.cluster](https://registry.terraform.io/providers/hashicorp/google/5.6.0/docs/resources/service_account) | resource |
-| [google_compute_zones.available](https://registry.terraform.io/providers/hashicorp/google/5.6.0/docs/data-sources/compute_zones) | data source |
-| [google_container_engine_versions.this](https://registry.terraform.io/providers/hashicorp/google/5.6.0/docs/data-sources/container_engine_versions) | data source |
+| [google_container_cluster.cluster](https://registry.terraform.io/providers/hashicorp/google/5.15.0/docs/resources/container_cluster) | resource |
+| [google_container_node_pool.system](https://registry.terraform.io/providers/hashicorp/google/5.15.0/docs/resources/container_node_pool) | resource |
+| [google_service_account.cluster](https://registry.terraform.io/providers/hashicorp/google/5.15.0/docs/resources/service_account) | resource |
+| [google_compute_zones.available](https://registry.terraform.io/providers/hashicorp/google/5.15.0/docs/data-sources/compute_zones) | data source |
+| [google_container_engine_versions.this](https://registry.terraform.io/providers/hashicorp/google/5.15.0/docs/data-sources/container_engine_versions) | data source |
 
 ## Inputs
 

--- a/gke/terraform/modules/cluster/README.md
+++ b/gke/terraform/modules/cluster/README.md
@@ -4,13 +4,13 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.3 |
-| <a name="requirement_google"></a> [google](#requirement\_google) | 5.15.0 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | 5.18.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_google"></a> [google](#provider\_google) | 5.15.0 |
+| <a name="provider_google"></a> [google](#provider\_google) | 5.18.0 |
 
 ## Modules
 
@@ -25,11 +25,11 @@
 
 | Name | Type |
 |------|------|
-| [google_container_cluster.cluster](https://registry.terraform.io/providers/hashicorp/google/5.15.0/docs/resources/container_cluster) | resource |
-| [google_container_node_pool.system](https://registry.terraform.io/providers/hashicorp/google/5.15.0/docs/resources/container_node_pool) | resource |
-| [google_service_account.cluster](https://registry.terraform.io/providers/hashicorp/google/5.15.0/docs/resources/service_account) | resource |
-| [google_compute_zones.available](https://registry.terraform.io/providers/hashicorp/google/5.15.0/docs/data-sources/compute_zones) | data source |
-| [google_container_engine_versions.this](https://registry.terraform.io/providers/hashicorp/google/5.15.0/docs/data-sources/container_engine_versions) | data source |
+| [google_container_cluster.cluster](https://registry.terraform.io/providers/hashicorp/google/5.18.0/docs/resources/container_cluster) | resource |
+| [google_container_node_pool.system](https://registry.terraform.io/providers/hashicorp/google/5.18.0/docs/resources/container_node_pool) | resource |
+| [google_service_account.cluster](https://registry.terraform.io/providers/hashicorp/google/5.18.0/docs/resources/service_account) | resource |
+| [google_compute_zones.available](https://registry.terraform.io/providers/hashicorp/google/5.18.0/docs/data-sources/compute_zones) | data source |
+| [google_container_engine_versions.this](https://registry.terraform.io/providers/hashicorp/google/5.18.0/docs/data-sources/container_engine_versions) | data source |
 
 ## Inputs
 

--- a/gke/terraform/modules/cluster/versions.tf
+++ b/gke/terraform/modules/cluster/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "5.15.0"
+      version = "5.18.0"
     }
   }
 }

--- a/gke/terraform/modules/cluster/versions.tf
+++ b/gke/terraform/modules/cluster/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "5.6.0"
+      version = "5.15.0"
     }
   }
 }

--- a/gke/terraform/modules/network/README.md
+++ b/gke/terraform/modules/network/README.md
@@ -4,13 +4,13 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.3 |
-| <a name="requirement_google"></a> [google](#requirement\_google) | 5.6.0 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | 5.15.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_google"></a> [google](#provider\_google) | 5.6.0 |
+| <a name="provider_google"></a> [google](#provider\_google) | 5.15.0 |
 
 ## Modules
 
@@ -20,11 +20,11 @@ No modules.
 
 | Name | Type |
 |------|------|
-| [google_compute_address.nat](https://registry.terraform.io/providers/hashicorp/google/5.6.0/docs/resources/compute_address) | resource |
-| [google_compute_network.this](https://registry.terraform.io/providers/hashicorp/google/5.6.0/docs/resources/compute_network) | resource |
-| [google_compute_router.router](https://registry.terraform.io/providers/hashicorp/google/5.6.0/docs/resources/compute_router) | resource |
-| [google_compute_router_nat.nat](https://registry.terraform.io/providers/hashicorp/google/5.6.0/docs/resources/compute_router_nat) | resource |
-| [google_compute_subnetwork.cluster](https://registry.terraform.io/providers/hashicorp/google/5.6.0/docs/resources/compute_subnetwork) | resource |
+| [google_compute_address.nat](https://registry.terraform.io/providers/hashicorp/google/5.15.0/docs/resources/compute_address) | resource |
+| [google_compute_network.this](https://registry.terraform.io/providers/hashicorp/google/5.15.0/docs/resources/compute_network) | resource |
+| [google_compute_router.router](https://registry.terraform.io/providers/hashicorp/google/5.15.0/docs/resources/compute_router) | resource |
+| [google_compute_router_nat.nat](https://registry.terraform.io/providers/hashicorp/google/5.15.0/docs/resources/compute_router_nat) | resource |
+| [google_compute_subnetwork.cluster](https://registry.terraform.io/providers/hashicorp/google/5.15.0/docs/resources/compute_subnetwork) | resource |
 
 ## Inputs
 

--- a/gke/terraform/modules/network/README.md
+++ b/gke/terraform/modules/network/README.md
@@ -4,13 +4,13 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.3 |
-| <a name="requirement_google"></a> [google](#requirement\_google) | 5.15.0 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | 5.18.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_google"></a> [google](#provider\_google) | 5.15.0 |
+| <a name="provider_google"></a> [google](#provider\_google) | 5.18.0 |
 
 ## Modules
 
@@ -20,11 +20,11 @@ No modules.
 
 | Name | Type |
 |------|------|
-| [google_compute_address.nat](https://registry.terraform.io/providers/hashicorp/google/5.15.0/docs/resources/compute_address) | resource |
-| [google_compute_network.this](https://registry.terraform.io/providers/hashicorp/google/5.15.0/docs/resources/compute_network) | resource |
-| [google_compute_router.router](https://registry.terraform.io/providers/hashicorp/google/5.15.0/docs/resources/compute_router) | resource |
-| [google_compute_router_nat.nat](https://registry.terraform.io/providers/hashicorp/google/5.15.0/docs/resources/compute_router_nat) | resource |
-| [google_compute_subnetwork.cluster](https://registry.terraform.io/providers/hashicorp/google/5.15.0/docs/resources/compute_subnetwork) | resource |
+| [google_compute_address.nat](https://registry.terraform.io/providers/hashicorp/google/5.18.0/docs/resources/compute_address) | resource |
+| [google_compute_network.this](https://registry.terraform.io/providers/hashicorp/google/5.18.0/docs/resources/compute_network) | resource |
+| [google_compute_router.router](https://registry.terraform.io/providers/hashicorp/google/5.18.0/docs/resources/compute_router) | resource |
+| [google_compute_router_nat.nat](https://registry.terraform.io/providers/hashicorp/google/5.18.0/docs/resources/compute_router_nat) | resource |
+| [google_compute_subnetwork.cluster](https://registry.terraform.io/providers/hashicorp/google/5.18.0/docs/resources/compute_subnetwork) | resource |
 
 ## Inputs
 

--- a/gke/terraform/modules/network/versions.tf
+++ b/gke/terraform/modules/network/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "5.15.0"
+      version = "5.18.0"
     }
   }
 }

--- a/gke/terraform/modules/network/versions.tf
+++ b/gke/terraform/modules/network/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "5.6.0"
+      version = "5.15.0"
     }
   }
 }

--- a/testing/aks/create_cluster_test.go
+++ b/testing/aks/create_cluster_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/gruntwork-io/terratest/modules/terraform"
 )
 
-const KubernetesVersion = "1.27"
+const KubernetesVersion = "1.28"
 
 func testCluster(t *testing.T, configOptions *terraform.Options) {
 	kubeconfig := terraform.Output(t, configOptions, "kubeconfig")

--- a/testing/eks/configuration/main.tf
+++ b/testing/eks/configuration/main.tf
@@ -12,7 +12,12 @@ resource "helm_release" "cluster_autoscaler" {
 
   repository = "https://kubernetes.github.io/autoscaler"
   chart      = "cluster-autoscaler"
-  version    = "9.29.0"
+  version    = "9.35.0"
+
+  set {
+    name  = "image.tag"
+    value = var.cluster_autoscaler_version
+  }
 
   values = [
     var.cluster_autoscaler_helm_values
@@ -25,7 +30,7 @@ resource "helm_release" "load_balancer_controller" {
 
   repository = "https://aws.github.io/eks-charts"
   chart      = "aws-load-balancer-controller"
-  version    = "1.5.3"
+  version    = "1.7.1"
 
   values = [
     var.load_balancer_controller_helm_values

--- a/testing/eks/configuration/variables.tf
+++ b/testing/eks/configuration/variables.tf
@@ -10,6 +10,10 @@ variable "cluster_autoscaler_helm_values" {
   type = string
 }
 
+variable "cluster_autoscaler_version" {
+  type = string
+}
+
 variable "load_balancer_controller_helm_values" {
   type = string
 }

--- a/testing/eks/create_cluster_test.go
+++ b/testing/eks/create_cluster_test.go
@@ -13,7 +13,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-const KubernetesVersion = "1.27"
+// cluster autoscaler version must match kubernetes version
+const KubernetesVersion = "1.28"
+const ClusterAutoscalerVersion = "v1.28.2"
 
 func testCluster(t *testing.T, configOptions *terraform.Options) {
 	kubeconfig := terraform.Output(t, configOptions, "kubeconfig")
@@ -103,6 +105,7 @@ func TestTerraformEksClusterComplete(t *testing.T) {
 			"load_balancer_controller_helm_values": loadBalancerValues,
 			"storage_class_path_gp2":               storageClassPathGp2,
 			"storage_class_path_gp3":               storageClassPathGp3,
+			"cluster_autoscaler_version":           ClusterAutoscalerVersion,
 		},
 		Upgrade: true,
 	})
@@ -201,6 +204,7 @@ func TestTerraformEksClusterExternalNetwork(t *testing.T) {
 			"load_balancer_controller_helm_values": loadBalancerValues,
 			"storage_class_path_gp2":               storageClassPathGp2,
 			"storage_class_path_gp3":               storageClassPathGp3,
+			"cluster_autoscaler_version":           ClusterAutoscalerVersion,
 		},
 		Upgrade: true,
 	})

--- a/testing/gke/configuration/versions.tf
+++ b/testing/gke/configuration/versions.tf
@@ -23,11 +23,12 @@ data "google_container_cluster" "main" {
   location = var.region
 }
 
+data "google_client_config" "provider" {}
+
 provider "kubernetes" {
-  host                   = "https://${data.google_container_cluster.main.endpoint}"
-  cluster_ca_certificate = base64decode(data.google_container_cluster.main.master_auth[0].cluster_ca_certificate)
-  exec {
-    api_version = "client.authentication.k8s.io/v1beta1"
-    command     = "gke-gcloud-auth-plugin"
-  }
+  host  = "https://${data.google_container_cluster.main.endpoint}"
+  token = data.google_client_config.provider.access_token
+  cluster_ca_certificate = base64decode(
+    data.google_container_cluster.main.master_auth[0].cluster_ca_certificate,
+  )
 }

--- a/testing/gke/create_cluster_test.go
+++ b/testing/gke/create_cluster_test.go
@@ -11,7 +11,7 @@ import (
 
 // Prerequisite, set the GCP project with: export TF_VAR_project=<project>
 
-const KubernetesVersion = "1.27"
+const KubernetesVersion = "1.28"
 
 func testCluster(t *testing.T, configOptions *terraform.Options) {
 	kubeconfig := terraform.Output(t, configOptions, "kubeconfig")

--- a/testing/prerequisites/outputs.tf
+++ b/testing/prerequisites/outputs.tf
@@ -1,5 +1,5 @@
 output "local_cidr" {
-  value = "${chomp(data.http.ip.body)}/32"
+  value = "${chomp(data.http.ip.response_body)}/32"
 }
 
 output "bastion_ssh_public_key" {


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

A few minor changes:

1) Updated the versions for the cloud terraform providers
2) Updated the kubernetes version in the tests to 1.28.
3) Updated the helm chart versions in the EKS README for the cluster-autoscaler and aws-load-balancer-controller dependencies (used those same versions in the tests)
4)  Updated bastion host instance type to Standard_B1s to give it a bit more uumph

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:
