### PR TITLE
chore(DATAGO-71049): Add test for EKS 1.29

### DIFF
--- a/testing/eks/create_cluster_test.go
+++ b/testing/eks/create_cluster_test.go
@@ -14,8 +14,8 @@ import (
 )
 
 // cluster autoscaler version must match kubernetes version
-const KubernetesVersion = "1.28"
-const ClusterAutoscalerVersion = "v1.28.2"
+const KubernetesVersion = "1.29"
+const ClusterAutoscalerVersion = "v1.29.0"
 
 func testCluster(t *testing.T, configOptions *terraform.Options) {
 	kubeconfig := terraform.Output(t, configOptions, "kubeconfig")


### PR DESCRIPTION
#### What type of PR is this?
This PR is to add test for EKS cluster version `1.29`

<!--
/kind feature
-->

#### What this PR does / why we need it:
This PR will use the EKS cluster cluster version `1.29` for testing the cluster creation instead of `1.28`


#### Special notes for your reviewer:
