### PR TITLE
Add 1.29 as default version for AKS and GKE

### DIFF
--- a/testing/aks/create_cluster_test.go
+++ b/testing/aks/create_cluster_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/gruntwork-io/terratest/modules/terraform"
 )
 
-const KubernetesVersion = "1.28"
+const KubernetesVersion = "1.29"
 
 func testCluster(t *testing.T, configOptions *terraform.Options) {
 	kubeconfig := terraform.Output(t, configOptions, "kubeconfig")

--- a/testing/gke/create_cluster_test.go
+++ b/testing/gke/create_cluster_test.go
@@ -11,7 +11,7 @@ import (
 
 // Prerequisite, set the GCP project with: export TF_VAR_project=<project>
 
-const KubernetesVersion = "1.28"
+const KubernetesVersion = "1.29"
 
 func testCluster(t *testing.T, configOptions *terraform.Options) {
 	kubeconfig := terraform.Output(t, configOptions, "kubeconfig")


### PR DESCRIPTION
#### What type of PR is this?

This PR is to add `1.29` as default version for testing GKE and AKS cluster.

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
This PR will use the AKS and GKE cluster version `1.29` for testing the cluster creation instead of `1.28`

Fixes #

#### Special notes for your reviewer:
