### PR TITLE
DATAGO-71704: Add instance type in EKS worker node defintion

### DIFF
--- a/eks/terraform/modules/broker-node-group/main.tf
+++ b/eks/terraform/modules/broker-node-group/main.tf
@@ -2,7 +2,6 @@ resource "aws_launch_template" "this" {
   name = var.node_group_name_prefix
 
   vpc_security_group_ids = var.security_group_ids
-  instance_type          = var.worker_node_instance_type
 
   block_device_mappings {
     device_name = "/dev/xvda"
@@ -39,6 +38,7 @@ resource "aws_eks_node_group" "this" {
   node_group_name_prefix = "${var.node_group_name_prefix}-${count.index}-"
   node_role_arn          = var.worker_node_role_arn
   subnet_ids             = [var.subnet_ids[count.index]]
+  version = "1.28"
 
   instance_types = [
     var.worker_node_instance_type

--- a/eks/terraform/modules/broker-node-group/main.tf
+++ b/eks/terraform/modules/broker-node-group/main.tf
@@ -40,6 +40,10 @@ resource "aws_eks_node_group" "this" {
   node_role_arn          = var.worker_node_role_arn
   subnet_ids             = [var.subnet_ids[count.index]]
 
+  instance_types = [
+    var.worker_node_instance_type
+  ]
+
   scaling_config {
     desired_size = var.node_group_desired_size
     min_size     = var.node_group_min_size


### PR DESCRIPTION
#### What type of PR is this?
/kind feature


#### What this PR does / why we need it:
This PR is to include `instance_types` details in EKS worker node definition. This is to make it backward compatible with existing clusters.

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for your reviewer:
