### PR TITLE
Switch to IRSAv2/pod identity

### DIFF
--- a/eks/terraform/modules/cluster/irsa.tf
+++ b/eks/terraform/modules/cluster/irsa.tf
@@ -1,0 +1,216 @@
+################################################################################
+# IRSA v1
+################################################################################
+
+data "tls_certificate" "eks_oidc_issuer" {
+  url = aws_eks_cluster.cluster.identity[0].oidc[0].issuer
+}
+
+resource "aws_iam_openid_connect_provider" "cluster" {
+  count           = var.use_irsa_v1 ? 1 : 0
+  client_id_list  = ["sts.amazonaws.com"]
+  thumbprint_list = [data.tls_certificate.eks_oidc_issuer.certificates[0].sha1_fingerprint]
+  url             = aws_eks_cluster.cluster.identity[0].oidc[0].issuer
+}
+
+moved {
+  from = aws_iam_openid_connect_provider.cluster
+  to   = aws_iam_openid_connect_provider.cluster[0]
+}
+
+module "cluster_autoscaler_irsa_role" {
+  count = var.use_irsa_v1 ? 1 : 0
+
+  source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
+  version = "5.34.0"
+
+  role_name          = "${var.cluster_name}-cluster-autoscaler"
+  policy_name_prefix = "${var.cluster_name}-"
+
+  attach_cluster_autoscaler_policy = true
+  cluster_autoscaler_cluster_ids   = [aws_eks_cluster.cluster.id]
+
+  oidc_providers = {
+    main = {
+      provider_arn               = aws_iam_openid_connect_provider.cluster.arn
+      namespace_service_accounts = ["kube-system:${local.cluster_autoscaler_service_account}"]
+    }
+  }
+}
+
+moved {
+  from = module.cluster_autoscaler_irsa_role
+  to   = module.cluster_autoscaler_irsa_role[0]
+}
+
+
+module "loadbalancer_controller_irsa_role" {
+  count = var.use_irsa_v1 ? 1 : 0
+
+  source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
+  version = "5.34.0"
+
+  role_name          = "${var.cluster_name}-loadbalancer-controller"
+  policy_name_prefix = "${var.cluster_name}-"
+
+  attach_load_balancer_controller_policy = true
+
+  oidc_providers = {
+    main = {
+      provider_arn               = aws_iam_openid_connect_provider.cluster.arn
+      namespace_service_accounts = ["kube-system:${local.loadbalancer_controller_service_account}"]
+    }
+  }
+}
+
+moved {
+  from = module.loadbalancer_controller_irsa_role
+  to   = module.loadbalancer_controller_irsa_role[0]
+}
+
+module "ebs_csi_irsa_role" {
+  count = var.use_irsa_v1 ? 1 : 0
+
+  source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
+  version = "5.34.0"
+
+  role_name          = "${var.cluster_name}-ebs-csi"
+  policy_name_prefix = "${var.cluster_name}-"
+
+  attach_ebs_csi_policy = true
+
+  oidc_providers = {
+    main = {
+      provider_arn               = aws_iam_openid_connect_provider.cluster.arn
+      namespace_service_accounts = ["kube-system:ebs-csi-controller-sa"]
+    }
+  }
+}
+
+moved {
+  from = module.ebs_csi_irsa_role
+  to   = module.ebs_csi_irsa_role[0]
+}
+
+module "vpc_cni_irsa_role" {
+  count = var.use_irsa_v1 ? 1 : 0
+
+  source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
+  version = "5.34.0"
+
+  role_name          = "${var.cluster_name}-vpc-cni"
+  policy_name_prefix = "${var.cluster_name}-"
+
+  attach_vpc_cni_policy = true
+  vpc_cni_enable_ipv4   = true
+
+  oidc_providers = {
+    main = {
+      provider_arn               = aws_iam_openid_connect_provider.cluster.arn
+      namespace_service_accounts = ["kube-system:aws-node"]
+    }
+  }
+}
+
+moved {
+  from = module.vpc_cni_irsa_role
+  to   = module.vpc_cni_irsa_role[0]
+}
+
+################################################################################
+# IRSA v1
+################################################################################
+module "cluster_autoscaler_pod_identity" {
+  count = var.use_irsa_v2 ? 1 : 0
+
+  source  = "terraform-aws-modules/eks-pod-identity/aws"
+  version = "1.2.1"
+
+  name = "${var.cluster_name}-ca"
+
+  attach_cluster_autoscaler_policy = true
+  cluster_autoscaler_cluster_names = [aws_eks_cluster.cluster.id]
+
+  # Pod Identity Associations
+  association_defaults = {
+    namespace       = local.contorllers_namespace
+    service_account = local.cluster_autoscaler_service_account
+  }
+
+  associations = {
+    cluster-autoscaler = {
+      cluster_name = aws_eks_cluster.cluster.id
+    }
+  }
+}
+
+module "aws_lb_controller_pod_identity" {
+  count = var.use_irsa_v2 ? 1 : 0
+
+  source  = "terraform-aws-modules/eks-pod-identity/aws"
+  version = "1.2.1"
+
+  name = "${var.cluster_name}-lbc"
+
+  attach_aws_lb_controller_policy = true
+
+  # Pod Identity Associations
+  association_defaults = {
+    namespace       = local.contorllers_namespace
+    service_account = local.loadbalancer_controller_service_account
+  }
+
+  associations = {
+    aws-lbc = {
+      cluster_name = aws_eks_cluster.cluster.id
+    }
+  }
+
+}
+
+module "aws_ebs_csi_pod_identity" {
+  count = var.use_irsa_v2 ? 1 : 0
+
+  source  = "terraform-aws-modules/eks-pod-identity/aws"
+  version = "1.2.1"
+
+  name = "${var.cluster_name}-ebs-csi"
+
+  attach_aws_ebs_csi_policy = true
+
+  # Pod Identity Associations
+  association_defaults = {
+    namespace       = local.contorllers_namespace
+    service_account = local.ebs_csi_controller_service_account
+  }
+
+  associations = {
+    ebs-csi = {
+      cluster_name = aws_eks_cluster.cluster.id
+    }
+  }
+}
+
+module "aws_vpc_cni_pod_identity" {
+  count = var.use_irsa_v2 ? 1 : 0
+  
+  source  = "terraform-aws-modules/eks-pod-identity/aws"
+  version = "1.2.1"
+
+  name = "${var.cluster_name}-vpc-cni"
+
+  attach_aws_vpc_cni_policy = true
+  aws_vpc_cni_enable_ipv4   = true
+
+  # Pod Identity Associations
+  association_defaults = {
+    namespace       = local.contorllers_namespace
+    service_account = local.vpc_cni_service_account
+  }
+
+  associations = {
+    vpc-cni = {
+      cluster_name = aws_eks_cluster.cluster.id
+    }
+  }
+}

--- a/eks/terraform/modules/cluster/irsa.tf
+++ b/eks/terraform/modules/cluster/irsa.tf
@@ -32,7 +32,7 @@ module "cluster_autoscaler_irsa_role" {
 
   oidc_providers = {
     main = {
-      provider_arn               = aws_iam_openid_connect_provider.cluster.arn
+      provider_arn               = aws_iam_openid_connect_provider.cluster[0].arn
       namespace_service_accounts = ["kube-system:${local.cluster_autoscaler_service_account}"]
     }
   }
@@ -57,7 +57,7 @@ module "loadbalancer_controller_irsa_role" {
 
   oidc_providers = {
     main = {
-      provider_arn               = aws_iam_openid_connect_provider.cluster.arn
+      provider_arn               = aws_iam_openid_connect_provider.cluster[0].arn
       namespace_service_accounts = ["kube-system:${local.loadbalancer_controller_service_account}"]
     }
   }
@@ -81,7 +81,7 @@ module "ebs_csi_irsa_role" {
 
   oidc_providers = {
     main = {
-      provider_arn               = aws_iam_openid_connect_provider.cluster.arn
+      provider_arn               = aws_iam_openid_connect_provider.cluster[0].arn
       namespace_service_accounts = ["kube-system:ebs-csi-controller-sa"]
     }
   }
@@ -106,7 +106,7 @@ module "vpc_cni_irsa_role" {
 
   oidc_providers = {
     main = {
-      provider_arn               = aws_iam_openid_connect_provider.cluster.arn
+      provider_arn               = aws_iam_openid_connect_provider.cluster[0].arn
       namespace_service_accounts = ["kube-system:aws-node"]
     }
   }

--- a/eks/terraform/modules/cluster/irsa.tf
+++ b/eks/terraform/modules/cluster/irsa.tf
@@ -129,6 +129,7 @@ module "cluster_autoscaler_pod_identity" {
   name = "${var.cluster_name}-ca"
 
   attach_cluster_autoscaler_policy = true
+  use_name_prefix                  = true
   cluster_autoscaler_cluster_names = [aws_eks_cluster.cluster.id]
 
   # Pod Identity Associations
@@ -153,6 +154,7 @@ module "aws_lb_controller_pod_identity" {
   name = "${var.cluster_name}-lbc"
 
   attach_aws_lb_controller_policy = true
+  use_name_prefix                 = true
 
   # Pod Identity Associations
   association_defaults = {
@@ -177,6 +179,7 @@ module "aws_ebs_csi_pod_identity" {
   name = "${var.cluster_name}-ebs-csi"
 
   attach_aws_ebs_csi_policy = true
+  use_name_prefix           = true
 
   # Pod Identity Associations
   association_defaults = {
@@ -201,6 +204,7 @@ module "aws_vpc_cni_pod_identity" {
 
   attach_aws_vpc_cni_policy = true
   aws_vpc_cni_enable_ipv4   = true
+  use_name_prefix           = true
 
   # Pod Identity Associations
   association_defaults = {

--- a/eks/terraform/modules/cluster/irsa.tf
+++ b/eks/terraform/modules/cluster/irsa.tf
@@ -193,7 +193,7 @@ module "aws_ebs_csi_pod_identity" {
 
 module "aws_vpc_cni_pod_identity" {
   count = var.use_irsa_v2 ? 1 : 0
-  
+
   source  = "terraform-aws-modules/eks-pod-identity/aws"
   version = "1.2.1"
 

--- a/eks/terraform/modules/cluster/main.tf
+++ b/eks/terraform/modules/cluster/main.tf
@@ -22,7 +22,7 @@ module "cluster_autoscaler_pod_identity" {
   source  = "terraform-aws-modules/eks-pod-identity/aws"
   version = "1.2.1"
 
-  name = "${var.cluster_name}-cluster-autoscaler"
+  name = "${var.cluster_name}-ca"
 
   attach_cluster_autoscaler_policy = true
   cluster_autoscaler_cluster_names = [aws_eks_cluster.cluster.id]
@@ -44,7 +44,7 @@ module "aws_lb_controller_pod_identity" {
   source  = "terraform-aws-modules/eks-pod-identity/aws"
   version = "1.2.1"
 
-  name = "${var.cluster_name}-loadbalancer-controller"
+  name = "${var.cluster_name}-lbc"
 
   attach_aws_lb_controller_policy = true
 

--- a/eks/terraform/modules/cluster/main.tf
+++ b/eks/terraform/modules/cluster/main.tf
@@ -235,7 +235,7 @@ resource "aws_cloudwatch_log_group" "cluster_logs" {
 resource "aws_eks_addon" "csi-driver" {
   cluster_name             = aws_eks_cluster.cluster.name
   addon_name               = "aws-ebs-csi-driver"
-  service_account_role_arn = var.use_irsa_v1 ? module.ebs_csi_irsa_role.iam_role_arn : null
+  service_account_role_arn = var.use_irsa_v1 ? module.ebs_csi_irsa_role[0].iam_role_arn : null
 
   resolve_conflicts_on_create = "OVERWRITE"
   resolve_conflicts_on_update = "PRESERVE"
@@ -254,7 +254,7 @@ resource "aws_eks_addon" "csi-driver" {
 resource "aws_eks_addon" "vpc-cni" {
   cluster_name             = aws_eks_cluster.cluster.name
   addon_name               = "vpc-cni"
-  service_account_role_arn = var.use_irsa_v1 ? module.vpc_cni_irsa_role.iam_role_arn : null
+  service_account_role_arn = var.use_irsa_v1 ? module.vpc_cni_irsa_role[0].iam_role_arn : null
 
   resolve_conflicts_on_create = "OVERWRITE"
   resolve_conflicts_on_update = "PRESERVE"

--- a/eks/terraform/modules/cluster/main.tf
+++ b/eks/terraform/modules/cluster/main.tf
@@ -1,7 +1,7 @@
 locals {
   cluster_autoscaler_service_account      = "cluster-autoscaler"
   loadbalancer_controller_service_account = "aws-load-balancer-controller"
-  ebs_csi_controller_service_account      = "ebs-csi-controller"
+  ebs_csi_controller_service_account      = "ebs-csi-controller-sa"
   vpc_cni_service_account                 = "aws-node"
   contorllers_namespace                   = "kube-system"
 

--- a/eks/terraform/modules/cluster/main.tf
+++ b/eks/terraform/modules/cluster/main.tf
@@ -350,7 +350,7 @@ resource "aws_eks_addon" "csi-driver-IRSAv2" {
 }
 
 resource "aws_eks_addon" "vpc-cni-IRSAv2" {
-  count = var.use_irsa_v1 ? 1 : 0
+  count = var.use_irsa_v2 ? 1 : 0
 
   cluster_name             = aws_eks_cluster.cluster.name
   addon_name               = "vpc-cni"

--- a/eks/terraform/modules/cluster/main.tf
+++ b/eks/terraform/modules/cluster/main.tf
@@ -275,7 +275,7 @@ resource "aws_eks_addon" "pod-identity" {
 
 #### CSI Driver and VPC CNI Addons for IRSA v1 ####
 
-resource "aws_eks_addon" "csi-driver-IRSAv1" {
+resource "aws_eks_addon" "csi-driver" {
   count = var.use_irsa_v1 ? 1 : 0
 
   cluster_name             = aws_eks_cluster.cluster.name
@@ -299,10 +299,10 @@ resource "aws_eks_addon" "csi-driver-IRSAv1" {
 
 moved {
   from = aws_eks_addon.csi-driver
-  to   = aws_eks_addon.csi-driver-IRSAv1[0]
+  to   = aws_eks_addon.csi-driver[0]
 }
 
-resource "aws_eks_addon" "vpc-cni-IRSAv1" {
+resource "aws_eks_addon" "vpc-cni" {
   count = var.use_irsa_v1 ? 1 : 0
 
   cluster_name             = aws_eks_cluster.cluster.name
@@ -323,7 +323,7 @@ resource "aws_eks_addon" "vpc-cni-IRSAv1" {
 
 moved {
   from = aws_eks_addon.vpc-cni
-  to   = aws_eks_addon.vpc-cni-IRSAv1[0]
+  to   = aws_eks_addon.vpc-cni[0]
 }
 
 #### CSI Driver and VPC CNI Addons for IRSA v2 ####

--- a/eks/terraform/modules/cluster/main.tf
+++ b/eks/terraform/modules/cluster/main.tf
@@ -1,6 +1,9 @@
 locals {
   cluster_autoscaler_service_account      = "cluster-autoscaler"
   loadbalancer_controller_service_account = "aws-load-balancer-controller"
+  ebs_csi_controller_service_account      = "ebs-csi-controller"
+  vpc_cni_service_account                 = "aws-node"
+  contorllers_namespace                   = "kube-system"
 
   default_instance_type    = "m5.large"
   prod1k_instance_type     = "r5.large"
@@ -15,86 +18,90 @@ locals {
 data "aws_partition" "current" {}
 data "aws_caller_identity" "current" {}
 
-################################################################################
-# Cluster IAM
-################################################################################
+module "cluster_autoscaler_pod_identity" {
+  source  = "terraform-aws-modules/eks-pod-identity/aws"
+  version = "1.2.1"
 
-data "tls_certificate" "eks_oidc_issuer" {
-  url = aws_eks_cluster.cluster.identity[0].oidc[0].issuer
-}
-
-resource "aws_iam_openid_connect_provider" "cluster" {
-  client_id_list  = ["sts.amazonaws.com"]
-  thumbprint_list = [data.tls_certificate.eks_oidc_issuer.certificates[0].sha1_fingerprint]
-  url             = aws_eks_cluster.cluster.identity[0].oidc[0].issuer
-}
-
-module "cluster_autoscaler_irsa_role" {
-  source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
-  version = "5.34.0"
-
-  role_name          = "${var.cluster_name}-cluster-autoscaler"
-  policy_name_prefix = "${var.cluster_name}-"
+  name = "${var.cluster_name}-cluster-autoscaler"
 
   attach_cluster_autoscaler_policy = true
-  cluster_autoscaler_cluster_ids   = [aws_eks_cluster.cluster.id]
+  cluster_autoscaler_cluster_names = [aws_eks_cluster.cluster.id]
 
-  oidc_providers = {
-    main = {
-      provider_arn               = aws_iam_openid_connect_provider.cluster.arn
-      namespace_service_accounts = ["kube-system:${local.cluster_autoscaler_service_account}"]
+  # Pod Identity Associations
+  association_defaults = {
+    namespace       = local.contorllers_namespace
+    service_account = local.cluster_autoscaler_service_account
+  }
+
+  associations = {
+    cluster-autoscaler = {
+      cluster_name = aws_eks_cluster.cluster.id
     }
   }
 }
 
-module "loadbalancer_controller_irsa_role" {
-  source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
-  version = "5.34.0"
+module "aws_lb_controller_pod_identity" {
+  source  = "terraform-aws-modules/eks-pod-identity/aws"
+  version = "1.2.1"
 
-  role_name          = "${var.cluster_name}-loadbalancer-controller"
-  policy_name_prefix = "${var.cluster_name}-"
+  name = "${var.cluster_name}-loadbalancer-controller"
 
-  attach_load_balancer_controller_policy = true
+  attach_aws_lb_controller_policy = true
 
-  oidc_providers = {
-    main = {
-      provider_arn               = aws_iam_openid_connect_provider.cluster.arn
-      namespace_service_accounts = ["kube-system:${local.loadbalancer_controller_service_account}"]
+  # Pod Identity Associations
+  association_defaults = {
+    namespace       = local.contorllers_namespace
+    service_account = local.loadbalancer_controller_service_account
+  }
+
+  associations = {
+    aws-lbc = {
+      cluster_name = aws_eks_cluster.cluster.id
+    }
+  }
+
+  tags = local.tags
+}
+
+module "aws_ebs_csi_pod_identity" {
+  source  = "terraform-aws-modules/eks-pod-identity/aws"
+  version = "1.2.1"
+
+  name = "${var.cluster_name}-ebs-csi"
+
+  attach_aws_ebs_csi_policy = true
+
+  # Pod Identity Associations
+  association_defaults = {
+    namespace       = local.contorllers_namespace
+    service_account = local.cluster_autoscaler_service_account
+  }
+
+  associations = {
+    ebs-csi = {
+      cluster_name = aws_eks_cluster.cluster.id
     }
   }
 }
 
-module "ebs_csi_irsa_role" {
-  source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
-  version = "5.34.0"
+module "aws_vpc_cni_pod_identity" {
+  source  = "terraform-aws-modules/eks-pod-identity/aws"
+  version = "1.2.1"
 
-  role_name          = "${var.cluster_name}-ebs-csi"
-  policy_name_prefix = "${var.cluster_name}-"
+  name = "${var.cluster_name}-vpc-cni"
 
-  attach_ebs_csi_policy = true
+  attach_aws_vpc_cni_policy = true
+  aws_vpc_cni_enable_ipv4   = true
 
-  oidc_providers = {
-    main = {
-      provider_arn               = aws_iam_openid_connect_provider.cluster.arn
-      namespace_service_accounts = ["kube-system:ebs-csi-controller-sa"]
-    }
+  # Pod Identity Associations
+  association_defaults = {
+    namespace       = local.contorllers_namespace
+    service_account = local.vpc_cni_service_account
   }
-}
 
-module "vpc_cni_irsa_role" {
-  source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
-  version = "5.34.0"
-
-  role_name          = "${var.cluster_name}-vpc-cni"
-  policy_name_prefix = "${var.cluster_name}-"
-
-  attach_vpc_cni_policy = true
-  vpc_cni_enable_ipv4   = true
-
-  oidc_providers = {
-    main = {
-      provider_arn               = aws_iam_openid_connect_provider.cluster.arn
-      namespace_service_accounts = ["kube-system:aws-node"]
+  associations = {
+    vpc-cni = {
+      cluster_name = aws_eks_cluster.cluster.id
     }
   }
 }
@@ -363,6 +370,18 @@ resource "aws_eks_addon" "coredns" {
 resource "aws_eks_addon" "kube-proxy" {
   cluster_name = aws_eks_cluster.cluster.name
   addon_name   = "kube-proxy"
+
+  resolve_conflicts_on_create = "OVERWRITE"
+  resolve_conflicts_on_update = "PRESERVE"
+
+  depends_on = [
+    aws_eks_node_group.default
+  ]
+}
+
+resource "aws_eks_addon" "pod-identity" {
+  cluster_name = aws_eks_cluster.cluster.name
+  addon_name   = "eks-pod-identity-agent"
 
   resolve_conflicts_on_create = "OVERWRITE"
   resolve_conflicts_on_update = "PRESERVE"

--- a/eks/terraform/modules/cluster/main.tf
+++ b/eks/terraform/modules/cluster/main.tf
@@ -382,10 +382,6 @@ resource "aws_eks_addon" "pod-identity" {
 
   resolve_conflicts_on_create = "OVERWRITE"
   resolve_conflicts_on_update = "PRESERVE"
-
-  depends_on = [
-    aws_eks_node_group.default
-  ]
 }
 
 ################################################################################

--- a/eks/terraform/modules/cluster/main.tf
+++ b/eks/terraform/modules/cluster/main.tf
@@ -233,8 +233,9 @@ resource "aws_cloudwatch_log_group" "cluster_logs" {
 ################################################################################
 
 resource "aws_eks_addon" "csi-driver" {
-  cluster_name = aws_eks_cluster.cluster.name
-  addon_name   = "aws-ebs-csi-driver"
+  cluster_name             = aws_eks_cluster.cluster.name
+  addon_name               = "aws-ebs-csi-driver"
+  service_account_role_arn = var.use_irsa_v1 ? module.ebs_csi_irsa_role.iam_role_arn : null
 
   resolve_conflicts_on_create = "OVERWRITE"
   resolve_conflicts_on_update = "PRESERVE"
@@ -251,8 +252,9 @@ resource "aws_eks_addon" "csi-driver" {
 }
 
 resource "aws_eks_addon" "vpc-cni" {
-  cluster_name = aws_eks_cluster.cluster.name
-  addon_name   = "vpc-cni"
+  cluster_name             = aws_eks_cluster.cluster.name
+  addon_name               = "vpc-cni"
+  service_account_role_arn = var.use_irsa_v1 ? module.vpc_cni_irsa_role.iam_role_arn : null
 
   resolve_conflicts_on_create = "OVERWRITE"
   resolve_conflicts_on_update = "PRESERVE"
@@ -652,7 +654,7 @@ locals {
     rbac : {
       serviceAccount : {
         name : local.cluster_autoscaler_service_account,
-        annotations: try(var.use_irsa_v1 ? {
+        annotations : try(var.use_irsa_v1 ? {
           "eks.amazonaws.com/role-arn" : module.cluster_autoscaler_irsa_role[0].iam_role_arn
         } : null)
       }
@@ -663,7 +665,7 @@ locals {
     clusterName : var.cluster_name,
     serviceAccount : {
       name : local.loadbalancer_controller_service_account,
-      annotations: try(var.use_irsa_v1 ? {
+      annotations : try(var.use_irsa_v1 ? {
         "eks.amazonaws.com/role-arn" : module.loadbalancer_controller_irsa_role[0].iam_role_arn
       } : null)
     }

--- a/eks/terraform/modules/cluster/main.tf
+++ b/eks/terraform/modules/cluster/main.tf
@@ -51,7 +51,7 @@ module "aws_lb_controller_pod_identity" {
   # Pod Identity Associations
   association_defaults = {
     namespace       = local.contorllers_namespace
-    service_account = local.loadbalancer_controller_service_account
+    service_account = local.ebs_csi_controller_service_account
   }
 
   associations = {
@@ -60,7 +60,6 @@ module "aws_lb_controller_pod_identity" {
     }
   }
 
-  tags = local.tags
 }
 
 module "aws_ebs_csi_pod_identity" {
@@ -323,7 +322,6 @@ resource "aws_cloudwatch_log_group" "cluster_logs" {
 resource "aws_eks_addon" "csi-driver" {
   cluster_name             = aws_eks_cluster.cluster.name
   addon_name               = "aws-ebs-csi-driver"
-  service_account_role_arn = module.ebs_csi_irsa_role.iam_role_arn
 
   resolve_conflicts_on_create = "OVERWRITE"
   resolve_conflicts_on_update = "PRESERVE"
@@ -342,7 +340,6 @@ resource "aws_eks_addon" "csi-driver" {
 resource "aws_eks_addon" "vpc-cni" {
   cluster_name             = aws_eks_cluster.cluster.name
   addon_name               = "vpc-cni"
-  service_account_role_arn = module.vpc_cni_irsa_role.iam_role_arn
 
   resolve_conflicts_on_create = "OVERWRITE"
   resolve_conflicts_on_update = "PRESERVE"

--- a/eks/terraform/modules/cluster/main.tf
+++ b/eks/terraform/modules/cluster/main.tf
@@ -740,10 +740,7 @@ locals {
     replicaCount : 2,
     rbac : {
       serviceAccount : {
-        name : local.cluster_autoscaler_service_account,
-        annotations : {
-          "eks.amazonaws.com/role-arn" : try(module.cluster_autoscaler_irsa_role.iam_role_arn, "")
-        }
+        name : local.cluster_autoscaler_service_account
       }
     }
   })
@@ -751,10 +748,7 @@ locals {
   load_balancer_controller_helm_values = yamlencode({
     clusterName : var.cluster_name,
     serviceAccount : {
-      name : local.loadbalancer_controller_service_account,
-      annotations : {
-        "eks.amazonaws.com/role-arn" : try(module.loadbalancer_controller_irsa_role.iam_role_arn, "")
-      }
+      name : local.loadbalancer_controller_service_account
     },
     defaultTags : var.common_tags
   })

--- a/eks/terraform/modules/cluster/main.tf
+++ b/eks/terraform/modules/cluster/main.tf
@@ -51,7 +51,7 @@ module "aws_lb_controller_pod_identity" {
   # Pod Identity Associations
   association_defaults = {
     namespace       = local.contorllers_namespace
-    service_account = local.ebs_csi_controller_service_account
+    service_account = local.loadbalancer_controller_service_account
   }
 
   associations = {
@@ -73,7 +73,7 @@ module "aws_ebs_csi_pod_identity" {
   # Pod Identity Associations
   association_defaults = {
     namespace       = local.contorllers_namespace
-    service_account = local.cluster_autoscaler_service_account
+    service_account = local.ebs_csi_controller_service_account
   }
 
   associations = {

--- a/eks/terraform/modules/cluster/main.tf
+++ b/eks/terraform/modules/cluster/main.tf
@@ -231,6 +231,48 @@ resource "aws_cloudwatch_log_group" "cluster_logs" {
 ################################################################################
 # Add-ons
 ################################################################################
+
+/*
+* Due to a bug in the AWS provider, where service_account_role_arn can be removed from the addon after being added
+* If user wants to switch to IRSA v1, they need to remove IAM role from the addon and reapply it manually so the changes will be applied
+* Here's the github issue: https://github.com/hashicorp/terraform-provider-aws/issues/30645
+*/
+
+resource "aws_eks_addon" "csi-driver" {
+  cluster_name             = aws_eks_cluster.cluster.name
+  addon_name               = "aws-ebs-csi-driver"
+  service_account_role_arn = var.use_irsa_v1 ? module.ebs_csi_irsa_role.iam_role_arn : null
+
+  resolve_conflicts_on_create = "OVERWRITE"
+  resolve_conflicts_on_update = "PRESERVE"
+
+  configuration_values = jsonencode({
+    controller = {
+      extraVolumeTags = var.common_tags
+    }
+  })
+
+  depends_on = [
+    aws_eks_node_group.default
+  ]
+}
+
+resource "aws_eks_addon" "vpc-cni" {
+  cluster_name             = aws_eks_cluster.cluster.name
+  addon_name               = "vpc-cni"
+  service_account_role_arn = var.use_irsa_v1 ? module.vpc_cni_irsa_role.iam_role_arn : null
+
+  resolve_conflicts_on_create = "OVERWRITE"
+  resolve_conflicts_on_update = "PRESERVE"
+
+  configuration_values = jsonencode({
+    env = {
+      WARM_IP_TARGET  = "1"
+      WARM_ENI_TARGET = "0"
+    }
+  })
+}
+
 resource "aws_eks_addon" "coredns" {
   cluster_name = aws_eks_cluster.cluster.name
   addon_name   = "coredns"
@@ -263,108 +305,6 @@ resource "aws_eks_addon" "pod-identity" {
 
   resolve_conflicts_on_create = "OVERWRITE"
   resolve_conflicts_on_update = "PRESERVE"
-}
-
-/*
-* Due to a bug in the AWS provider, where service_account_role_arn can be removed from the addon after being added
-* And in order to support the use of IRSA v1 and v2 in this module, we need to have the creation of csi-driver and vpc-cni addons associated 
-* with each mode, i.e if switch from IRSA v1 to IRSA v2, the csi-driver and the vpc-cni addons will be removed and re-created with the new mode.
-* Here's the github issue: https://github.com/hashicorp/terraform-provider-aws/issues/30645
-*/
-
-
-#### CSI Driver and VPC CNI Addons for IRSA v1 ####
-
-resource "aws_eks_addon" "csi-driver" {
-  count = var.use_irsa_v1 ? 1 : 0
-
-  cluster_name             = aws_eks_cluster.cluster.name
-  addon_name               = "aws-ebs-csi-driver"
-  service_account_role_arn = module.ebs_csi_irsa_role[0].iam_role_arn
-
-  resolve_conflicts_on_create = "OVERWRITE"
-  resolve_conflicts_on_update = "PRESERVE"
-  preserve = true
-
-  configuration_values = jsonencode({
-    controller = {
-      extraVolumeTags = var.common_tags
-    }
-  })
-
-  depends_on = [
-    aws_eks_node_group.default
-  ]
-}
-
-moved {
-  from = aws_eks_addon.csi-driver
-  to   = aws_eks_addon.csi-driver[0]
-}
-
-resource "aws_eks_addon" "vpc-cni" {
-  count = var.use_irsa_v1 ? 1 : 0
-
-  cluster_name             = aws_eks_cluster.cluster.name
-  addon_name               = "vpc-cni"
-  service_account_role_arn = module.vpc_cni_irsa_role[0].iam_role_arn
-
-  resolve_conflicts_on_create = "OVERWRITE"
-  resolve_conflicts_on_update = "PRESERVE"
-  preserve = true
-
-  configuration_values = jsonencode({
-    env = {
-      WARM_IP_TARGET  = "1"
-      WARM_ENI_TARGET = "0"
-    }
-  })
-}
-
-moved {
-  from = aws_eks_addon.vpc-cni
-  to   = aws_eks_addon.vpc-cni[0]
-}
-
-#### CSI Driver and VPC CNI Addons for IRSA v2 ####
-
-resource "aws_eks_addon" "csi-driver-IRSAv2" {
-  count = var.use_irsa_v2 ? 1 : 0
-
-  cluster_name             = aws_eks_cluster.cluster.name
-  addon_name               = "aws-ebs-csi-driver"
-
-  resolve_conflicts_on_create = "OVERWRITE"
-  resolve_conflicts_on_update = "PRESERVE"
-  preserve = true
-
-  configuration_values = jsonencode({
-    controller = {
-      extraVolumeTags = var.common_tags
-    }
-  })
-
-  depends_on = [
-    aws_eks_node_group.default
-  ]
-}
-
-resource "aws_eks_addon" "vpc-cni-IRSAv2" {
-  count = var.use_irsa_v2 ? 1 : 0
-
-  cluster_name             = aws_eks_cluster.cluster.name
-  addon_name               = "vpc-cni"
-
-  resolve_conflicts_on_create = "OVERWRITE"
-  resolve_conflicts_on_update = "PRESERVE"
-  preserve = true
-
-  configuration_values = jsonencode({
-    env = {
-      WARM_IP_TARGET  = "1"
-      WARM_ENI_TARGET = "0"
-    }
-  })
 }
 
 ################################################################################

--- a/eks/terraform/modules/cluster/variables.tf
+++ b/eks/terraform/modules/cluster/variables.tf
@@ -70,3 +70,15 @@ variable "use_random_suffix_in_node_group_name" {
   type        = bool
   default     = true
 }
+
+variable "use_irsa_v1" {
+  type        = bool
+  default     = true
+  description = "When set to true, the module will use IRSA v1 for attaching IAM roles to service accounts."
+}
+
+variable "use_irsa_v2" {
+  type        = bool
+  default     = false
+  description = "When set to true, the module will use IRSA v2 for attaching IAM roles to service accounts."
+}


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind feature
-->

#### What this PR does / why we need it:
This pull request encompasses the migration from AWS IAM Roles for Service Accounts (IRSA) to the new IRSAv2, also known as Pod Identity for Amazon EKS. The migration involves the installation of the `eks-pod-identity-agent` addon and updating several critical components to utilize Pod Identity instead of the traditional IRSA module.

### Changes
- **Installation of `eks-pod-identity-agent` Addon**: Added the `eks-pod-identity-agent` to our EKS clusters to enable the use of Pod Identity, which provides a more secure and flexible mechanism for associating AWS IAM roles with Kubernetes service accounts.
- **Migration of Components to Use Pod Identity**:
  - **Cluster Autoscaler**: Updated the Cluster Autoscaler to leverage Pod Identity for accessing AWS resources, enhancing security and scalability.
  - **AWS Load Balancer Controller**: Migrated the AWS Load Balancer Controller to use Pod Identity, ensuring secure and efficient load balancing operations.
  - **EBS CSI Driver**: Transitioned the EBS CSI Driver to utilize Pod Identity, improving security and efficiency in managing EBS volumes.
  - **VPC CNI Plugin**: Updated the VPC CNI Plugin to use Pod Identity, enhancing network security and performance.