### PR TITLE
DATAGO-80328: Refactor EKS node group name

### DIFF
--- a/eks/terraform/modules/broker-node-group/README.md
+++ b/eks/terraform/modules/broker-node-group/README.md
@@ -41,6 +41,7 @@ No modules.
 | <a name="input_node_group_taints"></a> [node\_group\_taints](#input\_node\_group\_taints) | Kubernetes taints added to worker nodes in the node groups. | `list(map(string))` | n/a | yes |
 | <a name="input_security_group_ids"></a> [security\_group\_ids](#input\_security\_group\_ids) | The security groups that will be attached to the worker nodes. | `list(string)` | n/a | yes |
 | <a name="input_subnet_ids"></a> [subnet\_ids](#input\_subnet\_ids) | The subnets that the node groups will use - a node group is created in each subnet. | `list(string)` | n/a | yes |
+| <a name="input_use_random_suffix_in_node_group_name"></a> [use\_random\_suffix\_in\_node\_group\_name](#input\_use\_random\_suffix\_in\_node\_group\_name) | Whether to use auto generated random suffix in node group name | `bool` | `true` | no |
 | <a name="input_worker_node_instance_type"></a> [worker\_node\_instance\_type](#input\_worker\_node\_instance\_type) | The instance type of the worker nodes. | `string` | n/a | yes |
 | <a name="input_worker_node_role_arn"></a> [worker\_node\_role\_arn](#input\_worker\_node\_role\_arn) | The ARN of the IAM role assigned to each worker node via an instance profile. | `string` | n/a | yes |
 | <a name="input_worker_node_tags"></a> [worker\_node\_tags](#input\_worker\_node\_tags) | Tags that are added to worker nodes. | `map(string)` | `{}` | no |

--- a/eks/terraform/modules/broker-node-group/main.tf
+++ b/eks/terraform/modules/broker-node-group/main.tf
@@ -35,10 +35,10 @@ resource "aws_launch_template" "this" {
 resource "aws_eks_node_group" "this" {
   count = length(var.subnet_ids)
 
-  cluster_name           = var.cluster_name
-  node_group_name_prefix = "${var.node_group_name_prefix}-${count.index}-"
-  node_role_arn          = var.worker_node_role_arn
-  subnet_ids             = [var.subnet_ids[count.index]]
+  cluster_name    = var.cluster_name
+  node_group_name = "${var.node_group_name_prefix}-${count.index}"
+  node_role_arn   = var.worker_node_role_arn
+  subnet_ids      = [var.subnet_ids[count.index]]
 
   scaling_config {
     desired_size = var.node_group_desired_size

--- a/eks/terraform/modules/broker-node-group/main.tf
+++ b/eks/terraform/modules/broker-node-group/main.tf
@@ -35,10 +35,11 @@ resource "aws_launch_template" "this" {
 resource "aws_eks_node_group" "this" {
   count = length(var.subnet_ids)
 
-  cluster_name    = var.cluster_name
-  node_group_name = "${var.node_group_name_prefix}-${count.index}"
-  node_role_arn   = var.worker_node_role_arn
-  subnet_ids      = [var.subnet_ids[count.index]]
+  cluster_name           = var.cluster_name
+  node_group_name_prefix = var.use_random_suffix_in_node_group_name ? "${var.node_group_name_prefix}-${count.index}-" : null
+  node_group_name        = var.use_random_suffix_in_node_group_name ? null : "${var.node_group_name_prefix}-${count.index}"
+  node_role_arn          = var.worker_node_role_arn
+  subnet_ids             = [var.subnet_ids[count.index]]
 
   scaling_config {
     desired_size = var.node_group_desired_size

--- a/eks/terraform/modules/broker-node-group/variables.tf
+++ b/eks/terraform/modules/broker-node-group/variables.tf
@@ -75,3 +75,9 @@ variable "worker_node_instance_type" {
   type        = string
   description = "The instance type of the worker nodes."
 }
+
+variable "use_random_suffix_in_node_group_name" {
+  description = "Whether to use auto generated random suffix in node group name"
+  type        = bool
+  default     = true
+}

--- a/eks/terraform/modules/cluster/README.md
+++ b/eks/terraform/modules/cluster/README.md
@@ -79,6 +79,7 @@
 | <a name="input_node_group_max_size"></a> [node\_group\_max\_size](#input\_node\_group\_max\_size) | The maximum size for the broker node groups in the cluster. | `number` | `10` | no |
 | <a name="input_private_subnet_ids"></a> [private\_subnet\_ids](#input\_private\_subnet\_ids) | The IDs of the private subnets where the worker nodes will reside. | `list(string)` | n/a | yes |
 | <a name="input_region"></a> [region](#input\_region) | The AWS region where this cluster will reside. | `string` | n/a | yes |
+| <a name="input_use_random_suffix_in_node_group_name"></a> [use\_random\_suffix\_in\_node\_group\_name](#input\_use\_random\_suffix\_in\_node\_group\_name) | Whether to use auto generated random suffix in node group name | `bool` | `true` | no |
 | <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | The ID of the VPC where the cluster will reside. | `string` | n/a | yes |
 
 ## Outputs

--- a/eks/terraform/modules/cluster/main.tf
+++ b/eks/terraform/modules/cluster/main.tf
@@ -503,7 +503,8 @@ resource "aws_launch_template" "default" {
 
 resource "aws_eks_node_group" "default" {
   cluster_name           = aws_eks_cluster.cluster.name
-  node_group_name_prefix = "${var.cluster_name}-default-"
+  node_group_name_prefix = var.use_random_suffix_in_node_group_name ? "${var.cluster_name}-default-" : null
+  node_group_name        = var.use_random_suffix_in_node_group_name ? null : "${var.cluster_name}-default"
   node_role_arn          = aws_iam_role.worker_node.arn
   subnet_ids             = var.private_subnet_ids
 
@@ -547,10 +548,11 @@ resource "aws_autoscaling_group_tag" "default_name_tag" {
 module "node_group_prod1k" {
   source = "../broker-node-group"
 
-  cluster_name           = aws_eks_cluster.cluster.name
-  node_group_name_prefix = "${var.cluster_name}-prod1k"
-  security_group_ids     = [aws_security_group.worker_node.id]
-  subnet_ids             = var.private_subnet_ids
+  cluster_name                         = aws_eks_cluster.cluster.name
+  use_random_suffix_in_node_group_name = var.use_random_suffix_in_node_group_name
+  node_group_name_prefix               = "${var.cluster_name}-prod1k"
+  security_group_ids                   = [aws_security_group.worker_node.id]
+  subnet_ids                           = var.private_subnet_ids
 
   worker_node_role_arn      = aws_iam_role.worker_node.arn
   worker_node_instance_type = local.prod1k_instance_type
@@ -588,10 +590,11 @@ module "node_group_prod1k" {
 module "node_group_prod10k" {
   source = "../broker-node-group"
 
-  cluster_name           = aws_eks_cluster.cluster.name
-  node_group_name_prefix = "${var.cluster_name}-prod10k"
-  security_group_ids     = [aws_security_group.worker_node.id]
-  subnet_ids             = var.private_subnet_ids
+  cluster_name                         = aws_eks_cluster.cluster.name
+  use_random_suffix_in_node_group_name = var.use_random_suffix_in_node_group_name
+  node_group_name_prefix               = "${var.cluster_name}-prod10k"
+  security_group_ids                   = [aws_security_group.worker_node.id]
+  subnet_ids                           = var.private_subnet_ids
 
   worker_node_role_arn      = aws_iam_role.worker_node.arn
   worker_node_instance_type = local.prod10k_instance_type
@@ -629,10 +632,11 @@ module "node_group_prod10k" {
 module "node_group_prod100k" {
   source = "../broker-node-group"
 
-  cluster_name           = aws_eks_cluster.cluster.name
-  node_group_name_prefix = "${var.cluster_name}-prod100k"
-  security_group_ids     = [aws_security_group.worker_node.id]
-  subnet_ids             = var.private_subnet_ids
+  cluster_name                         = aws_eks_cluster.cluster.name
+  use_random_suffix_in_node_group_name = var.use_random_suffix_in_node_group_name
+  node_group_name_prefix               = "${var.cluster_name}-prod100k"
+  security_group_ids                   = [aws_security_group.worker_node.id]
+  subnet_ids                           = var.private_subnet_ids
 
   worker_node_role_arn      = aws_iam_role.worker_node.arn
   worker_node_instance_type = local.prod100k_instance_type
@@ -670,10 +674,11 @@ module "node_group_prod100k" {
 module "node_group_monitoring" {
   source = "../broker-node-group"
 
-  cluster_name           = aws_eks_cluster.cluster.name
-  node_group_name_prefix = "${var.cluster_name}-monitoring"
-  security_group_ids     = [aws_security_group.worker_node.id]
-  subnet_ids             = var.private_subnet_ids
+  cluster_name                         = aws_eks_cluster.cluster.name
+  use_random_suffix_in_node_group_name = var.use_random_suffix_in_node_group_name
+  node_group_name_prefix               = "${var.cluster_name}-monitoring"
+  security_group_ids                   = [aws_security_group.worker_node.id]
+  subnet_ids                           = var.private_subnet_ids
 
   worker_node_role_arn      = aws_iam_role.worker_node.arn
   worker_node_instance_type = local.monitoring_instance_type

--- a/eks/terraform/modules/cluster/variables.tf
+++ b/eks/terraform/modules/cluster/variables.tf
@@ -64,3 +64,9 @@ variable "kubernetes_cluster_admin_arns" {
   default     = []
   description = "When kubernetes_cluster_auth_mode is set to 'API', user or role ARNs can be provided that will be given assigned AmazonEKSClusterAdminPolicy for this cluster."
 }
+
+variable "use_random_suffix_in_node_group_name" {
+  description = "Whether to use auto generated random suffix in node group name"
+  type        = bool
+  default     = true
+}


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind feature
-->

#### What this PR does / why we need it:
We use Datacenter ID to create EKS node group prefix currently. The node group prefix is having a length restriction of `37`. But the datacenter ID most of the times can be longer than that as it is also prefixed by ord ID. This PR is to overcome that limitation.

Instead of using node group prefix, this PR is to update it to use directly the node group name which can permit the length of `63` which should be sufficient to meet our length requirement.

Add a flag `use_random_suffix_in_node_group_name` to decide whether node group prefix approach is to be used. This is to make it backward compatible. The flag by default is set to `true` which will make sure that it does not break for existing consumer projects of the terraform module

#### Which issue(s) this PR fixes:


#### Special notes for your reviewer:
