### PR TITLE
Include cluster id in module output for AKS.

### DIFF
--- a/aks/terraform/modules/cluster/README.md
+++ b/aks/terraform/modules/cluster/README.md
@@ -64,5 +64,6 @@
 
 | Name | Description |
 |------|-------------|
+| <a name="output_cluster_id"></a> [cluster\_id](#output\_cluster\_id) | n/a |
 | <a name="output_cluster_name"></a> [cluster\_name](#output\_cluster\_name) | n/a |
 <!-- END_TF_DOCS -->

--- a/aks/terraform/modules/cluster/outputs.tf
+++ b/aks/terraform/modules/cluster/outputs.tf
@@ -1,3 +1,7 @@
 output "cluster_name" {
   value = azurerm_kubernetes_cluster.cluster.name
 }
+
+output "cluster_id" {
+  value = azurerm_kubernetes_cluster.cluster.id
+}


### PR DESCRIPTION
#### What type of PR is this?

#### What this PR does / why we need it:

This PR adds the cluster's ID in the output of the cluster module in the AKS project. This makes it simpler to use this module outside of the full project provided here, if desired.

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:
