### PR TITLE
DATAGO-79683: Use EKS 1.31 for testing

### DIFF
--- a/testing/eks/create_cluster_test.go
+++ b/testing/eks/create_cluster_test.go
@@ -14,8 +14,8 @@ import (
 )
 
 // cluster autoscaler version must match kubernetes version
-const KubernetesVersion = "1.29"
-const ClusterAutoscalerVersion = "v1.29.0"
+const KubernetesVersion = "1.31"
+const ClusterAutoscalerVersion = "v1.31.0"
 
 func testCluster(t *testing.T, configOptions *terraform.Options) {
 	kubeconfig := terraform.Output(t, configOptions, "kubeconfig")


### PR DESCRIPTION
#### What type of PR is this?

This PR is to add support for EKS `1.31` . 

#### What this PR does / why we need it:
Use `1.31` version for EKS testing

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for your reviewer:
