### PR TITLE
chore(DATAGO-87752): add restriction on gke cluster name length

### DIFF
--- a/gke/terraform/modules/bastion/variables.tf
+++ b/gke/terraform/modules/bastion/variables.tf
@@ -1,6 +1,11 @@
 variable "cluster_name" {
   type        = string
   description = "The name of the cluster and name (or name prefix) for all other infrastructure."
+
+  validation {
+    condition     = length(var.cluster_name) < 23
+    error_message = "Cluster name must be less than 23 characters to satisfy google_service_account length restriction."
+  }
 }
 
 variable "common_labels" {

--- a/gke/terraform/modules/cluster/variables.tf
+++ b/gke/terraform/modules/cluster/variables.tf
@@ -11,6 +11,11 @@ variable "region" {
 variable "cluster_name" {
   type        = string
   description = "The name of the cluster and name (or name prefix) for all other infrastructure."
+
+  validation {
+    condition     = length(var.cluster_name) < 25
+    error_message = "Cluster name must be less than 25 characters to satisfy google_service_account length restriction."
+  }
 }
 
 variable "common_labels" {


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Restrict cluster_name length on GKE clusters as google_service_account account_id has a max length of 30 characters and otherwise will throw an error.

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:
