### PR TITLE
feature/split_cidr: Split CIDR for VNET and subnet in network module for AKS

### DIFF
--- a/aks/terraform/main.tf
+++ b/aks/terraform/main.tf
@@ -18,7 +18,7 @@ module "network" {
   common_tags         = var.common_tags
   cluster_name        = var.cluster_name
 
-  vnet_cidr = var.vnet_cidr
+  vnet_cidr           = var.vnet_cidr
   cluster_subnet_cidr = var.vnet_cidr
 }
 

--- a/aks/terraform/main.tf
+++ b/aks/terraform/main.tf
@@ -19,6 +19,7 @@ module "network" {
   cluster_name        = var.cluster_name
 
   vnet_cidr = var.vnet_cidr
+  cluster_subnet_cidr = var.vnet_cidr
 }
 
 ################################################################################

--- a/aks/terraform/modules/network/main.tf
+++ b/aks/terraform/modules/network/main.tf
@@ -23,7 +23,6 @@ resource "azurerm_subnet" "cluster" {
   name                                      = "cluster"
   resource_group_name                       = var.resource_group_name
   virtual_network_name                      = azurerm_virtual_network.this[0].name
-  #address_prefixes                         = [var.vnet_cidr]
   address_prefixes                          = [var.cluster_subnet_cidr]
   private_endpoint_network_policies_enabled = false
 }
@@ -50,7 +49,6 @@ resource "azurerm_route" "cluster" {
   name                = "local"
   resource_group_name = var.resource_group_name
   route_table_name    = azurerm_route_table.cluster[0].name
-  #address_prefix     = var.vnet_cidr
-  address_prefix      = var.cluster_subnet_cidr
+  address_prefix      = var.vnet_cidr
   next_hop_type       = "VnetLocal"
 }

--- a/aks/terraform/modules/network/main.tf
+++ b/aks/terraform/modules/network/main.tf
@@ -23,7 +23,8 @@ resource "azurerm_subnet" "cluster" {
   name                                      = "cluster"
   resource_group_name                       = var.resource_group_name
   virtual_network_name                      = azurerm_virtual_network.this[0].name
-  address_prefixes                          = [var.vnet_cidr]
+  #address_prefixes                         = [var.vnet_cidr]
+  address_prefixes                          = [var.cluster_subnet_cidr]
   private_endpoint_network_policies_enabled = false
 }
 
@@ -49,6 +50,7 @@ resource "azurerm_route" "cluster" {
   name                = "local"
   resource_group_name = var.resource_group_name
   route_table_name    = azurerm_route_table.cluster[0].name
-  address_prefix      = var.vnet_cidr
+  #address_prefix     = var.vnet_cidr
+  address_prefix      = var.cluster_subnet_cidr
   next_hop_type       = "VnetLocal"
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

In some cases, it's desirable to not have the cluster's subnet use the same CIDR as the VNET, so in the network module add the ability to set them both independently. 

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:
