### PR TITLE
Add subnet cidr variable to AKS network module

### DIFF
--- a/aks/terraform/modules/network/README.md
+++ b/aks/terraform/modules/network/README.md
@@ -31,11 +31,12 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name) | The name of the cluster. | `string` | n/a | yes |
+| <a name="input_cluster_subnet_cidr"></a> [cluster\_subnet\_cidr](#input\_cluster\_subnet\_cidr) | The CIDR of the cluster's subnet. | `string` | `null` | no |
 | <a name="input_common_tags"></a> [common\_tags](#input\_common\_tags) | Tags that are added to all resources created by this module. | `map(string)` | `{}` | no |
 | <a name="input_create_network"></a> [create\_network](#input\_create\_network) | When set to false, networking (VNET, Subnets, etc) must be created externally. | `bool` | `true` | no |
 | <a name="input_region"></a> [region](#input\_region) | The Azure region where this network will reside. | `string` | n/a | yes |
 | <a name="input_resource_group_name"></a> [resource\_group\_name](#input\_resource\_group\_name) | The name of the resource group that will contain the network. | `string` | n/a | yes |
-| <a name="input_vnet_cidr"></a> [vnet\_cidr](#input\_vnet\_cidr) | The CIDR of the cluster's VNET and cluster subnet. | `string` | `null` | no |
+| <a name="input_vnet_cidr"></a> [vnet\_cidr](#input\_vnet\_cidr) | The CIDR of the cluster's VNET. | `string` | `null` | no |
 
 ## Outputs
 

--- a/aks/terraform/modules/network/main.tf
+++ b/aks/terraform/modules/network/main.tf
@@ -25,6 +25,13 @@ resource "azurerm_subnet" "cluster" {
   virtual_network_name                      = azurerm_virtual_network.this[0].name
   address_prefixes                          = [var.cluster_subnet_cidr]
   private_endpoint_network_policies_enabled = false
+
+  lifecycle {
+    precondition {
+      condition     = can(cidrhost(var.cluster_subnet_cidr, 0))
+      error_message = "A valid IPv4 CIDR must be provided for 'cluster_subnet_cidr' variable."
+    }
+  }
 }
 
 resource "azurerm_subnet_route_table_association" "cluster" {

--- a/aks/terraform/modules/network/variables.tf
+++ b/aks/terraform/modules/network/variables.tf
@@ -28,5 +28,11 @@ variable "cluster_name" {
 variable "vnet_cidr" {
   type        = string
   default     = null
-  description = "The CIDR of the cluster's VNET and cluster subnet."
+  description = "The CIDR of the cluster's VNET."
+}
+
+variable "cluster_subnet_cidr" {
+  type        = string
+  default     = null
+  description = "The CIDR of the cluster's subnet."
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

The subnet CIDR variable usage was added, but was missing the variable itself. Also added validation to ensure it's actually a CIDR.

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:
