### PR TITLE
Simplify GCP service account names to maximize cluster name

### DIFF
--- a/gke/terraform/modules/bastion/main.tf
+++ b/gke/terraform/modules/bastion/main.tf
@@ -1,8 +1,15 @@
 resource "google_service_account" "bastion" {
   count = var.create_bastion ? 1 : 0
 
-  account_id   = "${var.cluster_name}-bastion"
+  account_id   = "${var.cluster_name}-vm"
   display_name = "Service account for ${var.cluster_name} bastion"
+
+  lifecycle {
+    precondition {
+      condition     = length(var.cluster_name) <= 27
+      error_message = "Cluster name must be 27 characters or less to satisfy google_service_account length restriction."
+    }
+  }
 }
 
 data "google_compute_zones" "available" {

--- a/gke/terraform/modules/bastion/variables.tf
+++ b/gke/terraform/modules/bastion/variables.tf
@@ -1,11 +1,6 @@
 variable "cluster_name" {
   type        = string
   description = "The name of the cluster and name (or name prefix) for all other infrastructure."
-
-  validation {
-    condition     = length(var.cluster_name) < 23
-    error_message = "Cluster name must be less than 23 characters to satisfy google_service_account length restriction."
-  }
 }
 
 variable "common_labels" {

--- a/gke/terraform/modules/cluster/main.tf
+++ b/gke/terraform/modules/cluster/main.tf
@@ -11,7 +11,7 @@ locals {
 }
 
 resource "google_service_account" "cluster" {
-  account_id   = "${var.cluster_name}-nodes"
+  account_id   = var.cluster_name
   display_name = "Service account for ${var.cluster_name} worker nodes"
 }
 

--- a/gke/terraform/modules/cluster/variables.tf
+++ b/gke/terraform/modules/cluster/variables.tf
@@ -13,8 +13,8 @@ variable "cluster_name" {
   description = "The name of the cluster and name (or name prefix) for all other infrastructure."
 
   validation {
-    condition     = length(var.cluster_name) < 25
-    error_message = "Cluster name must be less than 25 characters to satisfy google_service_account length restriction."
+    condition     = length(var.cluster_name) <= 30
+    error_message = "Cluster name must be30 characters or less to satisfy google_service_account length restriction."
   }
 }
 

--- a/testing/common/common.go
+++ b/testing/common/common.go
@@ -3,6 +3,7 @@ package common
 import (
 	"bufio"
 	"fmt"
+	"math/rand"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -176,4 +177,20 @@ func TestSshToBastionHost(t *testing.T, bastionPublicIp string, bastionUsername 
 	}
 
 	ssh.CheckSshConnectionWithRetry(t, publicHost, 30, 5*time.Second)
+}
+
+const charset = "abcdefghijklmnopqrstuvwxyz0123456789"
+
+var seededRand *rand.Rand = rand.New(rand.NewSource(time.Now().UnixNano()))
+
+func stringWithCharset(length int, charset string) string {
+	b := make([]byte, length)
+	for i := range b {
+		b[i] = charset[seededRand.Intn(len(charset))]
+	}
+	return string(b)
+}
+
+func UniqueId(length int) string {
+	return stringWithCharset(length, charset)
 }

--- a/testing/gke/create_cluster_test.go
+++ b/testing/gke/create_cluster_test.go
@@ -1,6 +1,7 @@
 package gke
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -35,7 +36,12 @@ func TestTerraformGkeClusterComplete(t *testing.T) {
 	keepCluster := os.Getenv("KEEP_CLUSTER")
 
 	region := "europe-west1"
-	clusterName := "terratest-complete"
+
+	clusterName := os.Getenv("CLUSTER_NAME")
+	if clusterName == "" {
+		// 27 characters, which is the max length when bastion is created
+		clusterName = fmt.Sprintf("terratest-complete-%s", common.UniqueId(8))
+	}
 
 	prereqPath, _ := common.CopyTerraform(t, "../prerequisites")
 	prereqOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
@@ -107,7 +113,12 @@ func TestTerraformGkeClusterMessagingCidr(t *testing.T) {
 	keepCluster := os.Getenv("KEEP_CLUSTER")
 
 	region := "europe-west3"
-	clusterName := "terratest-cidr"
+
+	clusterName := os.Getenv("CLUSTER_NAME")
+	if clusterName == "" {
+		// 30 characters, which is the max length when bastion is not created
+		clusterName = fmt.Sprintf("terratest-cidr-%s", common.UniqueId(15))
+	}
 
 	prereqPath, _ := common.CopyTerraform(t, "../prerequisites")
 	prereqOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
@@ -174,7 +185,12 @@ func TestTerraformGkeClusterExternalNetwork(t *testing.T) {
 	keepCluster := os.Getenv("KEEP_CLUSTER")
 
 	region := "us-east1"
-	clusterName := "terratest-network"
+
+	clusterName := os.Getenv("CLUSTER_NAME")
+	if clusterName == "" {
+		// 30 characters, which is the max length when bastion is not created
+		clusterName = fmt.Sprintf("terratest-network-%s", common.UniqueId(12))
+	}
 
 	prereqPath, _ := common.CopyTerraform(t, "../prerequisites")
 	prereqOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Service account names can be a maximum of 30 characters, which limits the cluster name. Remove the suffix from the cluster service account and shorten the suffix for the bastion host so the cluster name can be maximized.

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:
