### PR TITLE
Remove 'AllMetrics' from AKS diagnostic settings

### DIFF
--- a/aks/terraform/modules/broker-node-pool/README.md
+++ b/aks/terraform/modules/broker-node-pool/README.md
@@ -26,7 +26,7 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_availability_zones"></a> [availability\_zones](#input\_availability\_zones) | The availability zones for the node pools - one pool is created in each zone. | `list(string)` | <pre>[<br>  "1",<br>  "2",<br>  "3"<br>]</pre> | no |
+| <a name="input_availability_zones"></a> [availability\_zones](#input\_availability\_zones) | The availability zones for the node pools - one pool is created in each zone. | `list(string)` | <pre>[<br/>  "1",<br/>  "2",<br/>  "3"<br/>]</pre> | no |
 | <a name="input_cluster_id"></a> [cluster\_id](#input\_cluster\_id) | The ID of the cluster. | `string` | n/a | yes |
 | <a name="input_common_tags"></a> [common\_tags](#input\_common\_tags) | Tags that are added to all resources created by this module. | `map(string)` | `{}` | no |
 | <a name="input_kubernetes_version"></a> [kubernetes\_version](#input\_kubernetes\_version) | The Kubernetes version for the node pools. | `string` | n/a | yes |

--- a/aks/terraform/modules/cluster/README.md
+++ b/aks/terraform/modules/cluster/README.md
@@ -35,7 +35,7 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_availability_zones"></a> [availability\_zones](#input\_availability\_zones) | The availability zones for the default (system) node pool. | `list(string)` | <pre>[<br>  "1",<br>  "2",<br>  "3"<br>]</pre> | no |
+| <a name="input_availability_zones"></a> [availability\_zones](#input\_availability\_zones) | The availability zones for the default (system) node pool. | `list(string)` | <pre>[<br/>  "1",<br/>  "2",<br/>  "3"<br/>]</pre> | no |
 | <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name) | The name of the cluster and name (or name prefix) for all other infrastructure. | `string` | n/a | yes |
 | <a name="input_common_tags"></a> [common\_tags](#input\_common\_tags) | Tags that are added to all resources created by this module. | `map(string)` | `{}` | no |
 | <a name="input_kubernetes_api_authorized_networks"></a> [kubernetes\_api\_authorized\_networks](#input\_kubernetes\_api\_authorized\_networks) | A list of CIDRs that can access the Kubernetes API, in addition to the VPC's CIDR (which is added by default). | `list(string)` | `[]` | no |

--- a/aks/terraform/modules/cluster/main.tf
+++ b/aks/terraform/modules/cluster/main.tf
@@ -167,9 +167,4 @@ resource "azurerm_monitor_diagnostic_setting" "cluster" {
   enabled_log {
     category = "kube-controller-manager"
   }
-
-  metric {
-    category = "AllMetrics"
-    enabled  = true
-  }
 }

--- a/gke/terraform/modules/cluster/main.tf
+++ b/gke/terraform/modules/cluster/main.tf
@@ -81,6 +81,7 @@ resource "google_container_cluster" "cluster" {
     #checkov:skip=CKV_GCP_68:Secure boot onfiguration not required, default node pool wil be deleted
 
     service_account = google_service_account.cluster.email
+    resource_labels = var.common_labels
   }
 
   release_channel {


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

The 'AllMetrics' setting for AKS cluster diagnostics settings is expensive and not needed when OpenTelemetry or Datadog or another observability tool is used, so it makes sense to remove it from this terraform project.

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:
