### PR TITLE
feat(DATAGO-88420): use new vm sizes for AKS

### DIFF
--- a/aks/terraform/variables.tf
+++ b/aks/terraform/variables.tf
@@ -148,3 +148,41 @@ variable "kubernetes_cluster_admin_users" {
   default     = []
   description = "A list of Azure AD users that will be assigned the 'Azure Kubernetes Service Cluster User Role' role for this cluster."
 }
+
+variable "messaging_node_pools" {
+  type = map(object({
+    vm_size = string
+  }))
+
+  default = {
+    "prod1k" = {
+      vm_size = "Standard_E2ds_v5"
+    },
+    "prod5k" = {
+      vm_size = "Standard_E4ds_v5"
+    }
+    "prod10k" = {
+      vm_size = "Standard_E4bds_v5"
+    },
+    "prod50k" = {
+      vm_size = "Standard_E8bds_v5"
+    },
+    "prod100k" = {
+      vm_size = "Standard_E8bds_v5"
+    },
+  }
+
+  description = "The configuration for the messaging node pools."
+}
+
+variable "system_vm_size" {
+  type        = string
+  default     = "Standard_D2s_v5"
+  description = "The default VM size for the worker nodes in the default (system) node pool."
+}
+
+variable "monitoring_vm_size" {
+  type        = string
+  default     = "Standard_D2s_v5"
+  description = "The default VM size for the worker nodes in the monitoring node pool."
+}

--- a/testing/aks/create_cluster_test.go
+++ b/testing/aks/create_cluster_test.go
@@ -162,7 +162,7 @@ func TestTerraformAksClusterExternalNetwork(t *testing.T) {
 	subnetId := terraform.Output(t, networkOptions, "subnet_id")
 	routeTableId := terraform.Output(t, networkOptions, "route_table_id")
 
-	underTestPath, _ := common.CopyTerraform(t, "../../aks/terraform")
+	underTestPath, _ := common.CopyTerraform(t, "../../aks/terraform", clusterSuffix)
 	underTestOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
 		TerraformDir: underTestPath,
 		NoColor:      true,


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Supports new default VM sizes for AKS
Adds variables to set the VM size from outside of the AKS module for backwards compatibility 

#### Which issue(s) this PR fixes:
Fixes #88420

#### Special notes for your reviewer:
