### PR TITLE
Only log autoscaler logs in AKS, the rest is optional.

### DIFF
--- a/aks/terraform/modules/cluster/main.tf
+++ b/aks/terraform/modules/cluster/main.tf
@@ -149,12 +149,10 @@ resource "azurerm_monitor_diagnostic_setting" "cluster" {
   target_resource_id         = azurerm_kubernetes_cluster.cluster.id
   log_analytics_workspace_id = azurerm_log_analytics_workspace.cluster.id
 
-  enabled_log {
-    category = "cluster-autoscaler"
-  }
+  log_analytics_destination_type = "Dedicated"
 
   enabled_log {
-    category = "kube-audit-admin"
+    category = "cluster-autoscaler"
   }
 
   metric {


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Even if using 'basic' logging the 'kube-audit-admin' logs costs about a dollar a day, which is reasonably expensive at scale. Remove it and leave only the cluster autoscaler logs.

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:
