### PR TITLE
chore(DATAGO-90978): use new vm sizes in aks

### DIFF
--- a/aks/README.md
+++ b/aks/README.md
@@ -41,7 +41,7 @@ The cluster has the following node pools:
 
 ##### Default (System)
 
-The default (system) node pool spans all three availability zones. By default there are two worker nodes in this pool. It uses the `Standard_D2s_v3` VM size. All the standard Kubernetes services as well as PubSub+ Mission Control Agent run on these worker nodes.
+The default (system) node pool spans all three availability zones. By default there are two worker nodes in this pool. It uses the `Standard_D2ds_v5` VM size. All the standard Kubernetes services as well as PubSub+ Mission Control Agent run on these worker nodes.
 
 ##### Event Broker Services
 
@@ -51,12 +51,12 @@ These node pools are engineered to support a 1:1 ratio of event broker service p
 
 The VM sizes, labels, and taints for each event broker service node pool are as follows:
 
-| Name       | VM size         | Labels                                      | Taints                                                          |
-|------------|-----------------|---------------------------------------------|-----------------------------------------------------------------|
-| prod1k     | Standard_E2s_v3 | nodeType:messaging<br>serviceClass:prod1k   | nodeType:messaging:NoExecute<br>serviceClass:prod1k:NoExecute   |
-| prod10k    | Standard_E4s_v3 | nodeType:messaging<br>serviceClass:prod10k  | nodeType:messaging:NoExecute<br>serviceClass:prod10k:NoExecute  |
-| prod100k   | Standard_E8s_v3 | nodeType:messaging<br>serviceClass:prod100k | nodeType:messaging:NoExecute<br>serviceClass:prod100k:NoExecute |
-| monitoring | Standard_D2s_v3 | nodeType:monitoring                         | nodeType:monitoring:NoExecute                                   |
+| Name       | VM size          | Labels                                      | Taints                                                          |
+|------------|------------------|---------------------------------------------|-----------------------------------------------------------------|
+| prod1k     | Standard_E2ds_v5 | nodeType:messaging<br>serviceClass:prod1k   | nodeType:messaging:NoExecute<br>serviceClass:prod1k:NoExecute   |
+| prod10k    | Standard_E4ds_v5 | nodeType:messaging<br>serviceClass:prod10k  | nodeType:messaging:NoExecute<br>serviceClass:prod10k:NoExecute  |
+| prod100k   | Standard_E8ds_v5 | nodeType:messaging<br>serviceClass:prod100k | nodeType:messaging:NoExecute<br>serviceClass:prod100k:NoExecute |
+| monitoring | Standard_D2ds_v5 | nodeType:monitoring                         | nodeType:monitoring:NoExecute                                   |
 
 ### Access<a name="aks-access"></a>
 

--- a/aks/terraform/main.tf
+++ b/aks/terraform/main.tf
@@ -84,12 +84,12 @@ module "cluster" {
 locals {
   os_disk_size_gb = 48
 
-  system_vm_size = "Standard_D2s_v3"
+  system_vm_size = "Standard_D2ds_v5"
 
-  prod1k_vm_size     = "Standard_E2s_v3"
-  prod10k_vm_size    = "Standard_E4s_v3"
-  prod100k_vm_size   = "Standard_E8s_v3"
-  monitoring_vm_size = "Standard_D2s_v3"
+  prod1k_vm_size     = "Standard_E2ds_v5"
+  prod10k_vm_size    = "Standard_E4ds_v5"
+  prod100k_vm_size   = "Standard_E8bds_v5"
+  monitoring_vm_size = "Standard_D2ds_v5"
 }
 
 module "node_pool_prod1k" {


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Set new AKS vm sizes for node groups. Changed from using v3 to v5 types.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

#### Special notes for your reviewer:
