### PR TITLE
chore(DATAGO-93343): Set node_os_upgrade_channel to None

### DIFF
--- a/aks/terraform/modules/cluster/main.tf
+++ b/aks/terraform/modules/cluster/main.tf
@@ -42,6 +42,7 @@ resource "azurerm_kubernetes_cluster" "cluster" {
   kubernetes_version      = var.kubernetes_version
   sku_tier                = "Standard"
   local_account_disabled  = var.local_account_disabled
+  node_os_upgrade_channel = var.node_os_upgrade_channel
 
   api_server_access_profile {
     authorized_ip_ranges = var.kubernetes_api_public_access ? var.kubernetes_api_authorized_networks : null

--- a/aks/terraform/modules/cluster/main.tf
+++ b/aks/terraform/modules/cluster/main.tf
@@ -42,7 +42,7 @@ resource "azurerm_kubernetes_cluster" "cluster" {
   kubernetes_version      = var.kubernetes_version
   sku_tier                = "Standard"
   local_account_disabled  = var.local_account_disabled
-  node_os_upgrade_channel = var.node_os_upgrade_channel
+  node_os_upgrade_channel = "None"
 
   api_server_access_profile {
     authorized_ip_ranges = var.kubernetes_api_public_access ? var.kubernetes_api_authorized_networks : null

--- a/aks/terraform/modules/cluster/variables.tf
+++ b/aks/terraform/modules/cluster/variables.tf
@@ -127,9 +127,3 @@ variable "worker_node_os_disk_type" {
   default     = "Ephemeral"
   description = "The type of the OS disk for the worker nodes in the default (system) node pool."
 }
-
-variable "node_os_upgrade_channel" {
-  type        = string
-  default     = "None"
-  description = "The upgrade channel for this Kubernetes Cluster Nodes' OS Image"
-}

--- a/aks/terraform/modules/cluster/variables.tf
+++ b/aks/terraform/modules/cluster/variables.tf
@@ -127,3 +127,9 @@ variable "worker_node_os_disk_type" {
   default     = "Ephemeral"
   description = "The type of the OS disk for the worker nodes in the default (system) node pool."
 }
+
+variable "node_os_upgrade_channel" {
+  type        = string
+  default     = "None"
+  description = "The upgrade channel for this Kubernetes Cluster Nodes' OS Image"
+}


### PR DESCRIPTION
#### What type of PR is this?

This parameter `node_os_upgrade_channel` set to None will disable work nodes auto upgrade. The node's OS will remain as it is unless manually upgraded. This is typically used when you want full control over when and how the OS is updated.

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:
