### PR TITLE
Add role assignment for roles/container.defaultNodeServiceAccount for GKE worker nodes

### DIFF
--- a/aks/terraform/modules/broker-node-pool/README.md
+++ b/aks/terraform/modules/broker-node-pool/README.md
@@ -26,7 +26,7 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_availability_zones"></a> [availability\_zones](#input\_availability\_zones) | The availability zones for the node pools - one pool is created in each zone. | `list(string)` | <pre>[<br>  "1",<br>  "2",<br>  "3"<br>]</pre> | no |
+| <a name="input_availability_zones"></a> [availability\_zones](#input\_availability\_zones) | The availability zones for the node pools - one pool is created in each zone. | `list(string)` | <pre>[<br/>  "1",<br/>  "2",<br/>  "3"<br/>]</pre> | no |
 | <a name="input_cluster_id"></a> [cluster\_id](#input\_cluster\_id) | The ID of the cluster. | `string` | n/a | yes |
 | <a name="input_common_tags"></a> [common\_tags](#input\_common\_tags) | Tags that are added to all resources created by this module. | `map(string)` | `{}` | no |
 | <a name="input_kubernetes_version"></a> [kubernetes\_version](#input\_kubernetes\_version) | The Kubernetes version for the node pools. | `string` | n/a | yes |

--- a/aks/terraform/modules/cluster/README.md
+++ b/aks/terraform/modules/cluster/README.md
@@ -35,7 +35,7 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_availability_zones"></a> [availability\_zones](#input\_availability\_zones) | The availability zones for the default (system) node pool. | `list(string)` | <pre>[<br>  "1",<br>  "2",<br>  "3"<br>]</pre> | no |
+| <a name="input_availability_zones"></a> [availability\_zones](#input\_availability\_zones) | The availability zones for the default (system) node pool. | `list(string)` | <pre>[<br/>  "1",<br/>  "2",<br/>  "3"<br/>]</pre> | no |
 | <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name) | The name of the cluster and name (or name prefix) for all other infrastructure. | `string` | n/a | yes |
 | <a name="input_common_tags"></a> [common\_tags](#input\_common\_tags) | Tags that are added to all resources created by this module. | `map(string)` | `{}` | no |
 | <a name="input_kubernetes_api_authorized_networks"></a> [kubernetes\_api\_authorized\_networks](#input\_kubernetes\_api\_authorized\_networks) | A list of CIDRs that can access the Kubernetes API, in addition to the VPC's CIDR (which is added by default). | `list(string)` | `[]` | no |

--- a/eks/terraform/modules/cluster-addons/README.md
+++ b/eks/terraform/modules/cluster-addons/README.md
@@ -17,10 +17,10 @@
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_aws_ebs_csi_pod_identity"></a> [aws\_ebs\_csi\_pod\_identity](#module\_aws\_ebs\_csi\_pod\_identity) | terraform-aws-modules/eks-pod-identity/aws | 1.7.0 |
-| <a name="module_aws_lb_controller_pod_identity"></a> [aws\_lb\_controller\_pod\_identity](#module\_aws\_lb\_controller\_pod\_identity) | terraform-aws-modules/eks-pod-identity/aws | 1.7.0 |
-| <a name="module_aws_vpc_cni_pod_identity"></a> [aws\_vpc\_cni\_pod\_identity](#module\_aws\_vpc\_cni\_pod\_identity) | terraform-aws-modules/eks-pod-identity/aws | 1.7.0 |
-| <a name="module_cluster_autoscaler_pod_identity"></a> [cluster\_autoscaler\_pod\_identity](#module\_cluster\_autoscaler\_pod\_identity) | terraform-aws-modules/eks-pod-identity/aws | 1.7.0 |
+| <a name="module_aws_ebs_csi_pod_identity"></a> [aws\_ebs\_csi\_pod\_identity](#module\_aws\_ebs\_csi\_pod\_identity) | terraform-aws-modules/eks-pod-identity/aws | 1.10.0 |
+| <a name="module_aws_lb_controller_pod_identity"></a> [aws\_lb\_controller\_pod\_identity](#module\_aws\_lb\_controller\_pod\_identity) | terraform-aws-modules/eks-pod-identity/aws | 1.10.0 |
+| <a name="module_aws_vpc_cni_pod_identity"></a> [aws\_vpc\_cni\_pod\_identity](#module\_aws\_vpc\_cni\_pod\_identity) | terraform-aws-modules/eks-pod-identity/aws | 1.10.0 |
+| <a name="module_cluster_autoscaler_pod_identity"></a> [cluster\_autoscaler\_pod\_identity](#module\_cluster\_autoscaler\_pod\_identity) | terraform-aws-modules/eks-pod-identity/aws | 1.10.0 |
 
 ## Resources
 

--- a/gke/terraform/modules/cluster/README.md
+++ b/gke/terraform/modules/cluster/README.md
@@ -21,6 +21,7 @@ No modules.
 | Name | Type |
 |------|------|
 | [google_container_cluster.cluster](https://registry.terraform.io/providers/hashicorp/google/6.10.0/docs/resources/container_cluster) | resource |
+| [google_project_iam_member.cluster_service_account_node_service_account](https://registry.terraform.io/providers/hashicorp/google/6.10.0/docs/resources/project_iam_member) | resource |
 | [google_service_account.cluster](https://registry.terraform.io/providers/hashicorp/google/6.10.0/docs/resources/service_account) | resource |
 | [google_container_engine_versions.this](https://registry.terraform.io/providers/hashicorp/google/6.10.0/docs/data-sources/container_engine_versions) | data source |
 

--- a/gke/terraform/modules/cluster/README.md
+++ b/gke/terraform/modules/cluster/README.md
@@ -21,7 +21,7 @@ No modules.
 | Name | Type |
 |------|------|
 | [google_container_cluster.cluster](https://registry.terraform.io/providers/hashicorp/google/6.10.0/docs/resources/container_cluster) | resource |
-| [google_project_iam_member.cluster_service_account_node_service_account](https://registry.terraform.io/providers/hashicorp/google/6.10.0/docs/resources/project_iam_member) | resource |
+| [google_project_iam_member.default_worker_node](https://registry.terraform.io/providers/hashicorp/google/6.10.0/docs/resources/project_iam_member) | resource |
 | [google_service_account.cluster](https://registry.terraform.io/providers/hashicorp/google/6.10.0/docs/resources/service_account) | resource |
 | [google_container_engine_versions.this](https://registry.terraform.io/providers/hashicorp/google/6.10.0/docs/data-sources/container_engine_versions) | data source |
 

--- a/gke/terraform/modules/cluster/main.tf
+++ b/gke/terraform/modules/cluster/main.tf
@@ -3,7 +3,7 @@ resource "google_service_account" "cluster" {
   display_name = "Service account for ${var.cluster_name} worker nodes"
 }
 
-resource "google_project_iam_member" "cluster_service_account_node_service_account" {
+resource "google_project_iam_member" "default_worker_node" {
   project = google_service_account.cluster.project
   role    = "roles/container.defaultNodeServiceAccount"
   member  = google_service_account.cluster.member

--- a/gke/terraform/modules/cluster/main.tf
+++ b/gke/terraform/modules/cluster/main.tf
@@ -3,6 +3,12 @@ resource "google_service_account" "cluster" {
   display_name = "Service account for ${var.cluster_name} worker nodes"
 }
 
+resource "google_project_iam_member" "cluster_service_account_node_service_account" {
+  project = google_service_account.cluster.project
+  role    = "roles/container.defaultNodeServiceAccount"
+  member  = google_service_account.cluster.member
+}
+
 ################################################################################
 # Cluster
 ################################################################################


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

It is recommended that the service account assigned to worker nodes in GKE have an assignment for the `roles/container.defaultNodeServiceAccount` role.

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:
