### PR TITLE
Upgrades eks cluster identity pods to latest version 1.12.1

### DIFF
--- a/eks/terraform/modules/cluster-addons/main.tf
+++ b/eks/terraform/modules/cluster-addons/main.tf
@@ -12,7 +12,7 @@ locals {
 
 module "cluster_autoscaler_pod_identity" {
   source  = "terraform-aws-modules/eks-pod-identity/aws"
-  version = "1.10.0"
+  version = "1.12.1"
 
   name               = "${var.cluster_name}-ca"
   policy_name_prefix = "${var.cluster_name}-"
@@ -35,7 +35,7 @@ module "cluster_autoscaler_pod_identity" {
 
 module "aws_lb_controller_pod_identity" {
   source  = "terraform-aws-modules/eks-pod-identity/aws"
-  version = "1.10.0"
+  version = "1.12.1"
 
   name               = "${var.cluster_name}-lbc"
   policy_name_prefix = "${var.cluster_name}-"
@@ -58,7 +58,7 @@ module "aws_lb_controller_pod_identity" {
 
 module "aws_ebs_csi_pod_identity" {
   source  = "terraform-aws-modules/eks-pod-identity/aws"
-  version = "1.10.0"
+  version = "1.12.1"
 
   name               = "${var.cluster_name}-ebs-csi"
   policy_name_prefix = "${var.cluster_name}-"
@@ -80,7 +80,7 @@ module "aws_ebs_csi_pod_identity" {
 
 module "aws_vpc_cni_pod_identity" {
   source  = "terraform-aws-modules/eks-pod-identity/aws"
-  version = "1.10.0"
+  version = "1.12.1"
 
   name               = "${var.cluster_name}-vpc-cni"
   policy_name_prefix = "${var.cluster_name}-"


### PR DESCRIPTION
#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->

#### What this PR does / why we need it:

This PR upgrades all `eks-pod-identity` module versions from `v1.10.0` to `v1.12.1` across the cluster-addons configuration. This ensures compatibility with the latest IAM policy updates required by various Kubernetes controllers when running on EKS `1.33`.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:
