### PR TITLE
Rebrand of Solace to remove PubSub+

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -2,10 +2,10 @@ blank_issues_enabled: false
 contact_links:
   - name: Support
     url: https://solace.com/support/
-    about: Contact Support if you have issues with your PubSub+ Cloud deployment.
+    about: Contact Support if you have issues with your Solace Cloud deployment.
   - name: Documentation
     url: https://docs.solace.com/
-    about: For more documentation about PubSub+ Cloud and the PubSub+ Event Broker.
+    about: For more documentation about Solace Cloud and the Solace Event Broker.
   - name: Community 
     url: https://solace.community/
     about: Ask the Solace community about anything Solace!

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -5,7 +5,7 @@ contact_links:
     about: Contact Support if you have issues with your Solace Cloud deployment.
   - name: Documentation
     url: https://docs.solace.com/
-    about: For more documentation about Solace Cloud and the Solace Event Broker.
+    about: For more documentation about Solace Cloud and Solace Event Broker Services.
   - name: Community 
     url: https://solace.community/
     about: Ask the Solace community about anything Solace!

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-v2.0%20adopted-ff69b4.svg)](CODE_OF_CONDUCT.md)
 
-# Kubernetes Terraform Reference Architectures for PubSub+ Cloud
+# Kubernetes Terraform Reference Architectures for Solace Cloud
 
 ## Overview
 
-[Solace PubSub+ Cloud](https://solace.com/products/event-broker/cloud/) provides multiple [deployment options](https://solace.com/resources/datasheets/deployment-options-for-pubsub-event-broker-cloud-datasheet) designed to meet various customer requirements. These Terraform projects provide a reference architecture for a Kubernetes cluster running in a [Customer-Controlled Region](https://docs.solace.com/Cloud/Deployment-Considerations/deployment-options.htm). The reference architectures include recommendations for:
+[Solace Cloud](https://solace.com/products/event-broker/cloud/) provides multiple [deployment options](https://solace.com/resources/datasheets/deployment-options-for-pubsub-event-broker-cloud-datasheet) designed to meet various customer requirements. These Terraform projects provide a reference architecture for a Kubernetes cluster running in a [Customer-Controlled Region](https://docs.solace.com/Cloud/Deployment-Considerations/deployment-options.htm). The reference architectures include recommendations for:
 
  * Node groups/pools with labels and taints for simple scheduling
  * VM sizes for each scaling tier that meet our [resource requirements](https://docs.solace.com/Cloud/Deployment-Considerations/resource-requirements-k8s.htm)
@@ -12,7 +12,7 @@
  * Recommended settings for storage classes
  * Configuration of required components (CSI, Austoscaler, Load Balancer Controller, etc)
 
-The reference architectures *do not* provide best practices for running Kubernetes. They are intended to provide an example that will provide easy integration with PubSub+ Cloud.
+The reference architectures *do not* provide best practices for running Kubernetes. They are intended to provide an example that will provide easy integration with Solace Cloud.
 
 Reference architectures are available for:
 
@@ -20,7 +20,7 @@ Reference architectures are available for:
  * [Azure Kubernetes Service (AKS)](aks/README.md)
  * [Google Kubernetes Engine (GKE)](gke/README.md)
 
-The Kubernetes versions supported in PubSub+ Cloud for EKS, AKS, and GKE are found in [Supported Kubernetes Versions](https://docs.solace.com/Cloud/Deployment-Considerations/cloud-broker-k8s-versions-support.htm) on the Solace documentation website.
+The Kubernetes versions supported in Solace Cloud for EKS, AKS, and GKE are found in [Supported Kubernetes Versions](https://docs.solace.com/Cloud/Deployment-Considerations/cloud-broker-k8s-versions-support.htm) on the Solace documentation website.
 
 ## Resources
 
@@ -30,7 +30,7 @@ For more information try these resources:
 - Ask the [Solace Community](https://solace.community)
 - The Solace Developer Portal website at: https://solace.dev
 
-If you have issues with your PubSub+ Cloud deployment, please contact [Support](https://solace.com/support/).
+If you have issues with your Solace Cloud deployment, please contact [Support](https://solace.com/support/).
 
 ## Contributing
 

--- a/aks/README.md
+++ b/aks/README.md
@@ -41,7 +41,7 @@ The cluster has the following node pools:
 
 ##### Default (System)
 
-The default (system) node pool spans all three availability zones. By default there are two worker nodes in this pool. It uses the `Standard_D2ds_v5` VM size. All the standard Kubernetes services, as well as the Solace Mission Control Agent, run on these worker nodes.
+The default (system) node pool spans all three availability zones. By default there are two worker nodes in this pool. It uses the `Standard_D2ds_v5` VM size. All the standard Kubernetes services, as well as the Mission Control Agent, run on these worker nodes.
 
 ##### Event Broker Services
 

--- a/aks/README.md
+++ b/aks/README.md
@@ -1,6 +1,6 @@
 # Reference Terraform for Azure Kubernetes Service
 
-We provide a sample Terraform that you can use as a reference to set up your Kubernetes cluster using Azure Kubernetes Service (AKS). This Terraform gives you recommended practices for the cluster to help ensure your deployment of PubSub+ Cloud is successful.
+We provide a sample Terraform that you can use as a reference to set up your Kubernetes cluster using Azure Kubernetes Service (AKS). This Terraform gives you recommended practices for the cluster to help ensure your deployment of Solace Cloud is successful.
 
 You can review the architecture and understand how to deploy using the Terraform. For information about the architecture, see:
 * [Architecture of AKS Reference Terraform](#aks-architecture)
@@ -12,8 +12,8 @@ The information on this page pertains to the Terraform. For information about th
 
 The sections describes the architecture reference Terraform project for deploying and Azure Kubernetes Service (AKS) cluster. It includes Kubernetes components and configuration that: 
 * are required (or highly recommended) to operate successfully with Solace Cloud
-* are recommended but not required to successfully deploy PubSub+ Cloud
-* are available to produce a working cluster but we are not opinionated on what to use (an option or configuraton had to be selected as part of the Terraform, but does not impact the installation of PubSub+ Cloud)
+* are recommended but not required to successfully deploy Solace Cloud
+* are available to produce a working cluster but we are not opinionated on what to use (an option or configuraton had to be selected as part of the Terraform, but does not impact the installation of Solace Cloud)
 
 The areas to review are the [networking](#aks-network), [cluster configuration](#aks-cluster-config), and [access to and from the cluster](#aks-access). Below is an architectural diagram of the components of the AKS cluster that are created with this Terraform project:
 
@@ -31,9 +31,9 @@ The VNET is an optional component. If the VNET that will host the cluster alread
 
 #### Networking
 
-There are currently two options for networking in AKS: Azure CNI and Kubenet. This Terraform project uses Kubenet, which is our recommended option as it provides the most efficient use of IP addresses within the VNET's CIDR. PubSub+ Cloud also supports Azure CNI and you can modify this Terraform project to use it. The result of doing so is a larger CIDR for the VNET, as we recommend a 1:1 event broker service pod to worker node ratio.
+There are currently two options for networking in AKS: Azure CNI and Kubenet. This Terraform project uses Kubenet, which is our recommended option as it provides the most efficient use of IP addresses within the VNET's CIDR. Solace Cloud also supports Azure CNI and you can modify this Terraform project to use it. The result of doing so is a larger CIDR for the VNET, as we recommend a 1:1 event broker service pod to worker node ratio.
 
-The [CIDR Calculator for PubSub+ Cloud](https://docs.solace.com/Cloud/Deployment-Considerations/CIDR_calculator/Solace-cloud-CIDR-calculator.xlsx) can be used to properly size the VNET to support the number of event broker services you require. A correctly sized VNET CIDR is critical as this cannot be changed once the cluster is created.
+The [CIDR Calculator for Solace Cloud](https://docs.solace.com/Cloud/Deployment-Considerations/CIDR_calculator/Solace-cloud-CIDR-calculator.xlsx) can be used to properly size the VNET to support the number of event broker services you require. A correctly sized VNET CIDR is critical as this cannot be changed once the cluster is created.
 
 #### Node Pools
 
@@ -41,7 +41,7 @@ The cluster has the following node pools:
 
 ##### Default (System)
 
-The default (system) node pool spans all three availability zones. By default there are two worker nodes in this pool. It uses the `Standard_D2ds_v5` VM size. All the standard Kubernetes services as well as PubSub+ Mission Control Agent run on these worker nodes.
+The default (system) node pool spans all three availability zones. By default there are two worker nodes in this pool. It uses the `Standard_D2ds_v5` VM size. All the standard Kubernetes services, as well as the Solace Mission Control Agent, run on these worker nodes.
 
 ##### Event Broker Services
 
@@ -94,8 +94,8 @@ To use this Terraform module, the following is required:
 
 1. Navigate to the `terraform/` directory and create a `terraform.tfvars` file with the required variables.
 
-* The VNET's CIDR must be sized appropriately for the number of event broker services that will be created, this can be done using the [CIDR Calculator for PubSub+ Cloud](https://docs.solace.com/Cloud/Deployment-Considerations/CIDR_calculator/Solace-cloud-CIDR-calculator.xlsx) using the 'AKS Kubenet' sheet.
-* The `kubernetes_version` variable should be set to the latest Kubernetes version that is [supported by PubSub+ Cloud](https://docs.solace.com/Cloud/Deployment-Considerations/cloud-broker-k8s-versions-support.htm).
+* The VNET's CIDR must be sized appropriately for the number of event broker services that will be created, this can be done using the [CIDR Calculator for Solace Cloud](https://docs.solace.com/Cloud/Deployment-Considerations/CIDR_calculator/Solace-cloud-CIDR-calculator.xlsx) using the 'AKS Kubenet' sheet.
+* The `kubernetes_version` variable should be set to the latest Kubernetes version that is [supported by Solace Cloud](https://docs.solace.com/Cloud/Deployment-Considerations/cloud-broker-k8s-versions-support.htm).
 * The `bastion_ssh_authorized_networks` variable must be set with the CIDR(s) of the networks where the bastion host will be accessed from.
 * The `bastion_ssh_public_key` variable must be set with the public key of the key pair that will be used to access the bastion host.
 * The `worker_node_ssh_public_key` variable must be set with the public key of the key pair that will be used to access the worker node hosts.

--- a/eks/README.md
+++ b/eks/README.md
@@ -2,7 +2,7 @@
 
 We provide a sample Terraform that you can use as a reference to set up your Kubernetes cluster using Amazon Elastic Kubernetes Service (EKS) cluster.
 This Terraform gives you a recommended practices for the cluster to help ensure
-your deployment of PubSub+ Cloud is successful.
+your deployment of Solace Cloud is successful.
 
 You can review the architecture and understand how to deploy using the Terraform.
 For information about the architecture, see:
@@ -17,9 +17,9 @@ for the Amazon EKS cluster, see the [documentation website](https://docs.solace.
 The section describes the architecture reference Terraform project for deploying an
 Amazon EKS cluster. This information includes Kubernetes components and configuration that:
 
- * are required (or highly recommended) to operate successfully with Solace PubSub+ Cloud
- * are recommended but not required to successfully deploy PubSub+ Cloud
- * are available to produce a working cluster but where Solace is not opinionated on what to use (an option or the configuration had to be selected as part of the Terraform and doesn't impact the installation of PubSub+ Cloud)
+ * are required (or highly recommended) to operate successfully with Solace Solace Cloud
+ * are recommended but not required to successfully deploy Solace Cloud
+ * are available to produce a working cluster but where Solace is not opinionated on what to use (an option or the configuration had to be selected as part of the Terraform and doesn't impact the installation of Solace Cloud)
 
 Review these sections below: [networking](#eks-network), [cluster configuration](#eks-cluster-configure), and [access to and from the cluster](#eks-access).
 
@@ -44,7 +44,7 @@ The private subnets contain:
 
 The public internet is accessed in the private subnets via the NAT Gateways. There are no restrictions on egress traffic to the public internet.
 
-The [CIDR Calculator for PubSub+ Cloud](https://docs.solace.com/Cloud/Deployment-Considerations/CIDR_calculator/cloud-CIDR-calculator.xlsx) can be used to properly size the VPC to support the number of event broker services that you require. A correctly sized VPC CIDR is important as this cannot be changed after the cluster has been created.
+The [CIDR Calculator for Solace Cloud](https://docs.solace.com/Cloud/Deployment-Considerations/CIDR_calculator/cloud-CIDR-calculator.xlsx) can be used to properly size the VPC to support the number of event broker services that you require. A correctly sized VPC CIDR is important as this cannot be changed after the cluster has been created.
 
 The VPC is an optional component. If the VPC that hosts the cluster exists or is created created with other automation, its details can be provided in variables.
 
@@ -59,7 +59,7 @@ The cluster has the following node groups:
 
 ##### Default (System)
 
-The default (system) node group spans all three availability zones. By default there are two worker nodes in this pool, and it uses the `m5.large` instance type. All the standard Kubernetes services, as well as the PubSub+ Mission Control Agent run on these worker nodes.
+The default (system) node group spans all three availability zones. By default there are two worker nodes in this pool, and it uses the `m5.large` instance type. All the standard Kubernetes services, as well as the Solace Mission Control Agent, run on these worker nodes.
 
 ##### Event Broker Services <a name="eks-broker-services"></a>
 
@@ -92,7 +92,7 @@ The Terraform project deploys the following add-ons:
  * kube-proxy
  * eks-pod-identity-agent
 
-PubSub+ Cloud also requires the use of `cluster-autoscaler` and `aws-load-balancer-controller` to operate. Instructions can be found below on how to deploy them into the cluster using the Helm values provided by the Terraform project.
+Solace Cloud also requires the use of `cluster-autoscaler` and `aws-load-balancer-controller` to operate. Instructions can be found below on how to deploy them into the cluster using the Helm values provided by the Terraform project.
 
 This project uses [EKS Pod Identities](https://docs.aws.amazon.com/eks/latest/userguide/pod-identities.html) to provide add-ons as well as the `cluster-autoscaler` and `aws-load-balancer-controller` with the appropriate AWS IAM permissions to operate.
 
@@ -138,9 +138,9 @@ To use this Terraform module, you require:
 
 ### Creating the Kubernetes Cluster <a name="eks-create-cluster"></a>
 
-1. Navigate to the `terraform/` directory and create a `terraform.tfvars` file with the required variables. The VPC and subnet CIDRs must be sized appropriately for the number of event broker services that you require to be created, this can be done using the (PubSub+ Cloud CIDR Calculator)[https://docs.solace.com/Cloud/Deployment-Considerations/CIDR_calculator/Solace-cloud-CIDR-calculator.xlsx].
+1. Navigate to the `terraform/` directory and create a `terraform.tfvars` file with the required variables. The VPC and subnet CIDRs must be sized appropriately for the number of event broker services that you require to be created, this can be done using the (Solace Cloud CIDR Calculator)[https://docs.solace.com/Cloud/Deployment-Considerations/CIDR_calculator/Solace-cloud-CIDR-calculator.xlsx].
 In the file, make the following changes:
-* The `kubernetes_version` variable should be set to the latest Kubernetes version that is [supported by PubSub+ Cloud](https://docs.solace.com/Cloud/Deployment-Considerations/cloud-broker-k8s-versions-support.htm).
+* The `kubernetes_version` variable should be set to the latest Kubernetes version that is [supported by Solace Cloud](https://docs.solace.com/Cloud/Deployment-Considerations/cloud-broker-k8s-versions-support.htm).
 * The `bastion_ssh_authorized_networks` variable must be set with the CIDRs of the networks where the bastion host will be accessed from.
 * The `bastion_ssh_public_key` variable must be set with the public key of the key pair that will be used to access the bastion host.
 
@@ -197,9 +197,9 @@ terraform apply
 
 ### Deploying Storage Class <a name="eks-deploy-storage"></a>
 
-There are two options for persistent storage that work well with Solace PubSub+ Cloud.
+There are two options for persistent storage that work well with Solace Solace Cloud.
 
-We recommend using GP2 as its performance can be configured by simply increasing the size of the disk, which can be done from within Solace PubSub+ Cloud.
+We recommend using GP2 as its performance can be configured by simply increasing the size of the disk, which can be done from within Solace Solace Cloud.
 
 Create a GP2 storage class with these recommended settings:
 

--- a/eks/README.md
+++ b/eks/README.md
@@ -17,7 +17,7 @@ for the Amazon EKS cluster, see the [documentation website](https://docs.solace.
 The section describes the architecture reference Terraform project for deploying an
 Amazon EKS cluster. This information includes Kubernetes components and configuration that:
 
- * are required (or highly recommended) to operate successfully with Solace Solace Cloud
+ * are required (or highly recommended) to operate successfully with Solace Cloud
  * are recommended but not required to successfully deploy Solace Cloud
  * are available to produce a working cluster but where Solace is not opinionated on what to use (an option or the configuration had to be selected as part of the Terraform and doesn't impact the installation of Solace Cloud)
 
@@ -59,7 +59,7 @@ The cluster has the following node groups:
 
 ##### Default (System)
 
-The default (system) node group spans all three availability zones. By default there are two worker nodes in this pool, and it uses the `m5.large` instance type. All the standard Kubernetes services, as well as the Solace Mission Control Agent, run on these worker nodes.
+The default (system) node group spans all three availability zones. By default there are two worker nodes in this pool, and it uses the `m5.large` instance type. All the standard Kubernetes services, as well as the Mission Control Agent, run on these worker nodes.
 
 ##### Event Broker Services <a name="eks-broker-services"></a>
 
@@ -197,9 +197,9 @@ terraform apply
 
 ### Deploying Storage Class <a name="eks-deploy-storage"></a>
 
-There are two options for persistent storage that work well with Solace Solace Cloud.
+There are two options for persistent storage that work well with Solace Cloud.
 
-We recommend using GP2 as its performance can be configured by simply increasing the size of the disk, which can be done from within Solace Solace Cloud.
+We recommend using GP2 as its performance can be configured by simply increasing the size of the disk, which can be done from within Solace Cloud.
 
 Create a GP2 storage class with these recommended settings:
 

--- a/gke/README.md
+++ b/gke/README.md
@@ -1,6 +1,6 @@
 # Reference Terraform for Google Kubernetes Engine
 
-We provide a sample Terraform that you can use as a reference to set up your Kubernetes cluster using Google Kubernetes Engine (GKE). This Terraform gives you a recommended practices for the cluster to help ensure your deployment of PubSub+ Cloud is successful.
+We provide a sample Terraform that you can use as a reference to set up your Kubernetes cluster using Google Kubernetes Engine (GKE). This Terraform gives you a recommended practices for the cluster to help ensure your deployment of Solace Cloud is successful.
 
 You can review the architecture and understand how to deploy using the Terraform.
 For information about the architecture, see:
@@ -14,9 +14,9 @@ for the GKE cluster, see the [documentation website](https://docs.solace.com/Clo
 
 This section describes the architecture reference Terraform project for deploying a GKE cluster. This information includes Kubernetes components and configuration that:
 
- * are required (or highly recommended) to operate successfully with Solace PubSub+ Cloud
- * are recommended but not required to successfully deploy PubSub+ Cloud
- * are available to produce a working cluster but where Solace is not opinionated on what to use (an option or the configuration had to be selected as part of the Terraform and doesn't impact the installation of PubSub+ Cloud)
+ * are required (or highly recommended) to operate successfully with Solace Solace Cloud
+ * are recommended but not required to successfully deploy Solace Cloud
+ * are available to produce a working cluster but where Solace is not opinionated on what to use (an option or the configuration had to be selected as part of the Terraform and doesn't impact the installation of Solace Cloud)
 
 Review these sections below: [networking](#gke-network), [cluster configuration](#gke-cluster-configure), and [access to and from the cluster](#gke-access).
 
@@ -60,7 +60,7 @@ The cluster has the following node pools:
 
 ##### Default (System)
 
-By default the pool has three worker nodes (one in each availability zone), and it uses the `n2-standard-2` machine type. All of the standard Kubernetes services and the Solace Mission Control Agent run on these worker nodes.
+By default the pool has three worker nodes (one in each availability zone), and it uses the `n2-standard-2` machine type. All of the standard Kubernetes services, as well as the Solace Mission Control Agent, run on these worker nodes.
 
 ##### Event Broker Services
 
@@ -106,7 +106,7 @@ To use this Terraform module, you require:
 
 1. Navigate to the `terraform/` directory and create a `terraform.tfvars` file with the required variables. The VPC and subnet CIDRs must be sized appropriately for the number of event broker services that you require to be created. Make the following changes in the file:
 
-* The `kubernetes_version` variable should be set to the latest Kubernetes version that is [supported by PubSub+ Cloud](https://docs.solace.com/Cloud/Deployment-Considerations/cloud-broker-k8s-versions-support.htm).
+* The `kubernetes_version` variable should be set to the latest Kubernetes version that is [supported by Solace Cloud](https://docs.solace.com/Cloud/Deployment-Considerations/cloud-broker-k8s-versions-support.htm).
 * The `network_cidr_range`, `secondary_cidr_range_pods`, and `secondary_cidr_range_services` variables set the CIDR ranges that will be used for the network, pods, and services. The `secondary_cidr_range_pods` and `secondary_cidr_range_services` variables end up as secondary CIDR ranges in the cluster's subnet and cannot overlap.
 * The `bastion_ssh_authorized_networks` variable must be set with the CIDRs of the networks where the bastion host will be accessed from.
 * The `bastion_ssh_public_key` variable must be set with the public key of the key pair that will be used to access the bastion host.

--- a/gke/README.md
+++ b/gke/README.md
@@ -14,7 +14,7 @@ for the GKE cluster, see the [documentation website](https://docs.solace.com/Clo
 
 This section describes the architecture reference Terraform project for deploying a GKE cluster. This information includes Kubernetes components and configuration that:
 
- * are required (or highly recommended) to operate successfully with Solace Solace Cloud
+ * are required (or highly recommended) to operate successfully with Solace Cloud
  * are recommended but not required to successfully deploy Solace Cloud
  * are available to produce a working cluster but where Solace is not opinionated on what to use (an option or the configuration had to be selected as part of the Terraform and doesn't impact the installation of Solace Cloud)
 
@@ -60,7 +60,7 @@ The cluster has the following node pools:
 
 ##### Default (System)
 
-By default the pool has three worker nodes (one in each availability zone), and it uses the `n2-standard-2` machine type. All of the standard Kubernetes services, as well as the Solace Mission Control Agent, run on these worker nodes.
+By default the pool has three worker nodes (one in each availability zone), and it uses the `n2-standard-2` machine type. All of the standard Kubernetes services, as well as the Mission Control Agent, run on these worker nodes.
 
 ##### Event Broker Services
 


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

Updated the use of 'PubSub+' to mostly just 'Solace'.

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:
