### PR TITLE
feat(DATAGO-109609): enable node pools that span AZs and allow specifying AMI type for EKS

### DIFF
--- a/aks/terraform/modules/broker-node-pool/README.md
+++ b/aks/terraform/modules/broker-node-pool/README.md
@@ -35,6 +35,7 @@ No modules.
 | <a name="input_node_pool_max_size"></a> [node\_pool\_max\_size](#input\_node\_pool\_max\_size) | The maximum worker node count for each node pool. | `string` | n/a | yes |
 | <a name="input_node_pool_name"></a> [node\_pool\_name](#input\_node\_pool\_name) | The name prefix of the node pools. | `string` | n/a | yes |
 | <a name="input_node_pool_taints"></a> [node\_pool\_taints](#input\_node\_pool\_taints) | Kubernetes taints added to worker nodes in the node pools. | `list(string)` | n/a | yes |
+| <a name="input_split_node_group"></a> [split\_node\_group](#input\_split\_node\_group) | Whether to split the nodegroup into a nodegroup per availability zone. | `bool` | `true` | no |
 | <a name="input_subnet_id"></a> [subnet\_id](#input\_subnet\_id) | The subnet that will contain the worker nodes in each node pool. | `string` | n/a | yes |
 | <a name="input_worker_node_disk_size"></a> [worker\_node\_disk\_size](#input\_worker\_node\_disk\_size) | The OS disk size (in GB) used for the worker nodes in each node pool. | `string` | n/a | yes |
 | <a name="input_worker_node_disk_type"></a> [worker\_node\_disk\_type](#input\_worker\_node\_disk\_type) | The type of the OS disk for the worker nodes in each node pool. | `string` | `"Ephemeral"` | no |

--- a/aks/terraform/modules/broker-node-pool/main.tf
+++ b/aks/terraform/modules/broker-node-pool/main.tf
@@ -1,5 +1,5 @@
 resource "azurerm_kubernetes_cluster_node_pool" "this" {
-  count = length(var.availability_zones)
+  count = var.split_node_group ? length(var.availability_zones) : 1
 
   name = "${var.node_pool_name}${count.index}"
   tags = var.common_tags
@@ -18,7 +18,7 @@ resource "azurerm_kubernetes_cluster_node_pool" "this" {
 
   max_pods = var.max_pods_per_node
 
-  zones          = [var.availability_zones[count.index]]
+  zones          = var.split_node_group ? [var.availability_zones[count.index]] : var.availability_zones
   vnet_subnet_id = var.subnet_id
 
   vm_size         = var.worker_node_vm_size

--- a/aks/terraform/modules/broker-node-pool/variables.tf
+++ b/aks/terraform/modules/broker-node-pool/variables.tf
@@ -20,6 +20,12 @@ variable "availability_zones" {
   description = "The availability zones for the node pools - one pool is created in each zone."
 }
 
+variable "split_node_group" {
+  type        = bool
+  description = "Whether to split the nodegroup into a nodegroup per availability zone."
+  default     = true
+}
+
 variable "subnet_id" {
   type        = string
   description = "The subnet that will contain the worker nodes in each node pool."

--- a/eks/terraform/modules/broker-node-group/README.md
+++ b/eks/terraform/modules/broker-node-group/README.md
@@ -41,6 +41,7 @@ No modules.
 | <a name="input_node_group_resources_tags"></a> [node\_group\_resources\_tags](#input\_node\_group\_resources\_tags) | Resources tags added to the node groups as hints for the autoscaler. | `list(map(string))` | n/a | yes |
 | <a name="input_node_group_taints"></a> [node\_group\_taints](#input\_node\_group\_taints) | Kubernetes taints added to worker nodes in the node groups. | `list(map(string))` | n/a | yes |
 | <a name="input_security_group_ids"></a> [security\_group\_ids](#input\_security\_group\_ids) | The security groups that will be attached to the worker nodes. | `list(string)` | n/a | yes |
+| <a name="input_split_node_group"></a> [split\_node\_group](#input\_split\_node\_group) | Whether to split the nodegroup into a nodegroup per subnet. | `bool` | `true` | no |
 | <a name="input_subnet_ids"></a> [subnet\_ids](#input\_subnet\_ids) | The subnets that the node groups will use - a node group is created in each subnet. | `list(string)` | n/a | yes |
 | <a name="input_worker_node_ami_version"></a> [worker\_node\_ami\_version](#input\_worker\_node\_ami\_version) | Value of the the AMI to use for the worker nodes. | `string` | n/a | yes |
 | <a name="input_worker_node_instance_type"></a> [worker\_node\_instance\_type](#input\_worker\_node\_instance\_type) | The instance type of the worker nodes. | `string` | n/a | yes |

--- a/eks/terraform/modules/broker-node-group/README.md
+++ b/eks/terraform/modules/broker-node-group/README.md
@@ -43,7 +43,8 @@ No modules.
 | <a name="input_security_group_ids"></a> [security\_group\_ids](#input\_security\_group\_ids) | The security groups that will be attached to the worker nodes. | `list(string)` | n/a | yes |
 | <a name="input_split_node_group"></a> [split\_node\_group](#input\_split\_node\_group) | Whether to split the nodegroup into a nodegroup per subnet. | `bool` | `true` | no |
 | <a name="input_subnet_ids"></a> [subnet\_ids](#input\_subnet\_ids) | The subnets that the node groups will use - a node group is created in each subnet. | `list(string)` | n/a | yes |
-| <a name="input_worker_node_ami_version"></a> [worker\_node\_ami\_version](#input\_worker\_node\_ami\_version) | Value of the the AMI to use for the worker nodes. | `string` | n/a | yes |
+| <a name="input_worker_node_ami_type"></a> [worker\_node\_ami\_type](#input\_worker\_node\_ami\_type) | Value of the AMI type to use for the worker nodes. | `string` | `"AL2023_x86_64_STANDARD"` | no |
+| <a name="input_worker_node_ami_version"></a> [worker\_node\_ami\_version](#input\_worker\_node\_ami\_version) | Value of the the AMI version to use for the worker nodes. | `string` | n/a | yes |
 | <a name="input_worker_node_instance_type"></a> [worker\_node\_instance\_type](#input\_worker\_node\_instance\_type) | The instance type of the worker nodes. | `string` | n/a | yes |
 | <a name="input_worker_node_role_arn"></a> [worker\_node\_role\_arn](#input\_worker\_node\_role\_arn) | The ARN of the IAM role assigned to each worker node via an instance profile. | `string` | n/a | yes |
 | <a name="input_worker_node_tags"></a> [worker\_node\_tags](#input\_worker\_node\_tags) | Tags that are added to worker nodes. | `map(string)` | `{}` | no |

--- a/eks/terraform/modules/broker-node-group/main.tf
+++ b/eks/terraform/modules/broker-node-group/main.tf
@@ -33,12 +33,12 @@ resource "aws_launch_template" "this" {
 }
 
 resource "aws_eks_node_group" "this" {
-  count = length(var.subnet_ids)
+  count = var.split_node_group ? length(var.subnet_ids) : 1
 
   cluster_name    = var.cluster_name
   node_group_name = "${var.node_group_name_prefix}-${count.index}"
   node_role_arn   = var.worker_node_role_arn
-  subnet_ids      = [var.subnet_ids[count.index]]
+  subnet_ids      = var.split_node_group ? [var.subnet_ids[count.index]] : var.subnet_ids
 
   version         = var.kubernetes_version
   release_version = var.worker_node_ami_version

--- a/eks/terraform/modules/broker-node-group/main.tf
+++ b/eks/terraform/modules/broker-node-group/main.tf
@@ -42,6 +42,7 @@ resource "aws_eks_node_group" "this" {
 
   version         = var.kubernetes_version
   release_version = var.worker_node_ami_version
+  ami_type        = var.worker_node_ami_type
 
   scaling_config {
     desired_size = var.node_group_desired_size

--- a/eks/terraform/modules/broker-node-group/variables.tf
+++ b/eks/terraform/modules/broker-node-group/variables.tf
@@ -61,6 +61,12 @@ variable "node_group_resources_tags" {
   description = "Resources tags added to the node groups as hints for the autoscaler."
 }
 
+variable "split_node_group" {
+  type        = bool
+  description = "Whether to split the nodegroup into a nodegroup per subnet."
+  default     = true
+}
+
 variable "worker_node_volume_size" {
   type        = number
   description = "The size of the worker node root disk."

--- a/eks/terraform/modules/broker-node-group/variables.tf
+++ b/eks/terraform/modules/broker-node-group/variables.tf
@@ -89,5 +89,11 @@ variable "worker_node_instance_type" {
 
 variable "worker_node_ami_version" {
   type        = string
-  description = "Value of the the AMI to use for the worker nodes."
+  description = "Value of the the AMI version to use for the worker nodes."
+}
+
+variable "worker_node_ami_type" {
+  type        = string
+  description = "Value of the AMI type to use for the worker nodes."
+  default     = "AL2023_x86_64_STANDARD"
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

- Allows `broker-node-pool` modules to create node pools that span availability zones in EKS and AKS.

- Allows specifying `ami_type` of EKS node groups to enable creation of `arm64` nodes which use `AL2023_ARM_64_STANDARD`.

#### Which issue(s) this PR fixes:
Partially completes `DATAGO-109609` and `DATAGO-109610`.

#### Special notes for your reviewer:
