### PR TITLE
DATAGO-117447: Add storage class for GCP hd-balanced disk type

### DIFF
--- a/gke/kubernetes/storage-class-hd-balanced.yaml
+++ b/gke/kubernetes/storage-class-hd-balanced.yaml
@@ -1,0 +1,9 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: hd-balanced
+provisioner: pd.csi.storage.gke.io
+parameters:
+  type: hyperdisk-balanced
+volumeBindingMode: WaitForFirstConsumer
+allowVolumeExpansion: true


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
This PR adds the storage class definition for `GCP` `hd-balanced` disk type which will be required by newer machine types.

#### Which issue(s) this PR fixes:

Fixes the issue with volume provisioning if newer machine type is used where `hd-balanced` disk type is used

#### Special notes for your reviewer:
