### PR TITLE
feat: allow creating EKS default node group with autoscaling disabled.

### DIFF
--- a/eks/terraform/modules/cluster-addons/README.md
+++ b/eks/terraform/modules/cluster-addons/README.md
@@ -17,10 +17,10 @@
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_aws_ebs_csi_pod_identity"></a> [aws\_ebs\_csi\_pod\_identity](#module\_aws\_ebs\_csi\_pod\_identity) | terraform-aws-modules/eks-pod-identity/aws | 1.10.0 |
-| <a name="module_aws_lb_controller_pod_identity"></a> [aws\_lb\_controller\_pod\_identity](#module\_aws\_lb\_controller\_pod\_identity) | terraform-aws-modules/eks-pod-identity/aws | 1.10.0 |
-| <a name="module_aws_vpc_cni_pod_identity"></a> [aws\_vpc\_cni\_pod\_identity](#module\_aws\_vpc\_cni\_pod\_identity) | terraform-aws-modules/eks-pod-identity/aws | 1.10.0 |
-| <a name="module_cluster_autoscaler_pod_identity"></a> [cluster\_autoscaler\_pod\_identity](#module\_cluster\_autoscaler\_pod\_identity) | terraform-aws-modules/eks-pod-identity/aws | 1.10.0 |
+| <a name="module_aws_ebs_csi_pod_identity"></a> [aws\_ebs\_csi\_pod\_identity](#module\_aws\_ebs\_csi\_pod\_identity) | terraform-aws-modules/eks-pod-identity/aws | 1.12.1 |
+| <a name="module_aws_lb_controller_pod_identity"></a> [aws\_lb\_controller\_pod\_identity](#module\_aws\_lb\_controller\_pod\_identity) | terraform-aws-modules/eks-pod-identity/aws | 1.12.1 |
+| <a name="module_aws_vpc_cni_pod_identity"></a> [aws\_vpc\_cni\_pod\_identity](#module\_aws\_vpc\_cni\_pod\_identity) | terraform-aws-modules/eks-pod-identity/aws | 1.12.1 |
+| <a name="module_cluster_autoscaler_pod_identity"></a> [cluster\_autoscaler\_pod\_identity](#module\_cluster\_autoscaler\_pod\_identity) | terraform-aws-modules/eks-pod-identity/aws | 1.12.1 |
 
 ## Resources
 

--- a/eks/terraform/modules/default-node-group/README.md
+++ b/eks/terraform/modules/default-node-group/README.md
@@ -31,6 +31,7 @@ No modules.
 | <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name) | The name of the cluster and name (or name prefix) for all other infrastructure. | `string` | n/a | yes |
 | <a name="input_kubernetes_version"></a> [kubernetes\_version](#input\_kubernetes\_version) | The kubernetes version to use. | `string` | n/a | yes |
 | <a name="input_node_group_desired_size"></a> [node\_group\_desired\_size](#input\_node\_group\_desired\_size) | The desired size of the node group. | `number` | n/a | yes |
+| <a name="input_node_group_max_size"></a> [node\_group\_max\_size](#input\_node\_group\_max\_size) | The maximum size of the node group. | `number` | `3` | no |
 | <a name="input_node_group_name"></a> [node\_group\_name](#input\_node\_group\_name) | The name the node group. | `string` | n/a | yes |
 | <a name="input_security_group_ids"></a> [security\_group\_ids](#input\_security\_group\_ids) | The security groups that will be attached to the worker nodes. | `list(string)` | n/a | yes |
 | <a name="input_subnet_ids"></a> [subnet\_ids](#input\_subnet\_ids) | The subnets that the node group will use. | `list(string)` | n/a | yes |

--- a/eks/terraform/modules/default-node-group/main.tf
+++ b/eks/terraform/modules/default-node-group/main.tf
@@ -44,7 +44,7 @@ resource "aws_eks_node_group" "this" {
   scaling_config {
     desired_size = var.node_group_desired_size
     min_size     = 0
-    max_size     = 3
+    max_size     = var.node_group_max_size
   }
 
   launch_template {

--- a/eks/terraform/modules/default-node-group/variables.tf
+++ b/eks/terraform/modules/default-node-group/variables.tf
@@ -34,6 +34,12 @@ variable "node_group_desired_size" {
   description = "The desired size of the node group."
 }
 
+variable "node_group_max_size" {
+  type        = number
+  description = "The maximum size of the node group."
+  default     = 3
+}
+
 variable "worker_node_volume_size" {
   type        = number
   description = "The size of the worker node root disk."


### PR DESCRIPTION
#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->

#### What this PR does / why we need it:
- Allows creating EKS default node groups with autoscaling disabled by node group making max size a variable.

#### Which issue(s) this PR fixes:
- Helpful for DATAGO-118863.
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

#### Special notes for your reviewer:
