### PR TITLE
DATAGO-125074: Add secondary VPC CIDR for EKS, AKS and GKE

### DIFF
--- a/aks/terraform/modules/cluster/main.tf
+++ b/aks/terraform/modules/cluster/main.tf
@@ -44,6 +44,8 @@ resource "azurerm_kubernetes_cluster" "cluster" {
   local_account_disabled  = var.local_account_disabled
   node_os_upgrade_channel = "None"
 
+  oidc_issuer_enabled = true
+
   api_server_access_profile {
     authorized_ip_ranges = var.kubernetes_api_public_access ? var.kubernetes_api_authorized_networks : null
   }

--- a/aks/terraform/modules/cluster/outputs.tf
+++ b/aks/terraform/modules/cluster/outputs.tf
@@ -13,3 +13,7 @@ output "cluster_id" {
 output "current_kubernetes_version" {
   value = azurerm_kubernetes_cluster.cluster.current_kubernetes_version
 }
+
+output "oidc_issuer_url" {
+  value = azurerm_kubernetes_cluster.cluster.oidc_issuer_url
+}

--- a/aks/terraform/modules/network/README.md
+++ b/aks/terraform/modules/network/README.md
@@ -21,6 +21,7 @@ No modules.
 | Name | Type |
 |------|------|
 | [azurerm_route.cluster](https://registry.terraform.io/providers/hashicorp/azurerm/4.11.0/docs/resources/route) | resource |
+| [azurerm_route.cluster_secondary](https://registry.terraform.io/providers/hashicorp/azurerm/4.11.0/docs/resources/route) | resource |
 | [azurerm_route_table.cluster](https://registry.terraform.io/providers/hashicorp/azurerm/4.11.0/docs/resources/route_table) | resource |
 | [azurerm_subnet.cluster](https://registry.terraform.io/providers/hashicorp/azurerm/4.11.0/docs/resources/subnet) | resource |
 | [azurerm_subnet_route_table_association.cluster](https://registry.terraform.io/providers/hashicorp/azurerm/4.11.0/docs/resources/subnet_route_table_association) | resource |
@@ -36,6 +37,7 @@ No modules.
 | <a name="input_create_network"></a> [create\_network](#input\_create\_network) | When set to false, networking (VNET, Subnets, etc) must be created externally. | `bool` | `true` | no |
 | <a name="input_region"></a> [region](#input\_region) | The Azure region where this network will reside. | `string` | n/a | yes |
 | <a name="input_resource_group_name"></a> [resource\_group\_name](#input\_resource\_group\_name) | The name of the resource group that will contain the network. | `string` | n/a | yes |
+| <a name="input_secondary_vnet_cidr"></a> [secondary\_vnet\_cidr](#input\_secondary\_vnet\_cidr) | An optional secondary CIDR block to associate with the cluster's VNET. This can be used to expand the cluster's available IP address space without needing to create a new VNET and migrate resources. | `string` | `null` | no |
 | <a name="input_vnet_cidr"></a> [vnet\_cidr](#input\_vnet\_cidr) | The CIDR of the cluster's VNET. | `string` | `null` | no |
 
 ## Outputs

--- a/aks/terraform/modules/network/README.md
+++ b/aks/terraform/modules/network/README.md
@@ -40,6 +40,7 @@ No modules.
 | <a name="input_region"></a> [region](#input\_region) | The Azure region where this network will reside. | `string` | n/a | yes |
 | <a name="input_resource_group_name"></a> [resource\_group\_name](#input\_resource\_group\_name) | The name of the resource group that will contain the network. | `string` | n/a | yes |
 | <a name="input_secondary_cluster_subnet_cidr"></a> [secondary\_cluster\_subnet\_cidr](#input\_secondary\_cluster\_subnet\_cidr) | The CIDR of the secondary cluster subnet. Required when secondary\_vnet\_cidr is set. | `string` | `null` | no |
+| <a name="input_secondary_cluster_subnet_delegation"></a> [secondary\_cluster\_subnet\_delegation](#input\_secondary\_cluster\_subnet\_delegation) | Optional delegation configuration for the secondary cluster subnet. | <pre>object({<br>    name = string<br>    service_delegation = object({<br>      name    = string<br>      actions = list(string)<br>    })<br>  })</pre> | `null` | no |
 | <a name="input_secondary_vnet_cidr"></a> [secondary\_vnet\_cidr](#input\_secondary\_vnet\_cidr) | An optional secondary CIDR block to associate with the cluster's VNET. This can be used to expand the cluster's available IP address space without needing to create a new VNET and migrate resources. | `string` | `null` | no |
 | <a name="input_vnet_cidr"></a> [vnet\_cidr](#input\_vnet\_cidr) | The CIDR of the cluster's VNET. | `string` | `null` | no |
 
@@ -50,4 +51,5 @@ No modules.
 | <a name="output_route_table_id"></a> [route\_table\_id](#output\_route\_table\_id) | n/a |
 | <a name="output_secondary_subnet_id"></a> [secondary\_subnet\_id](#output\_secondary\_subnet\_id) | n/a |
 | <a name="output_subnet_id"></a> [subnet\_id](#output\_subnet\_id) | n/a |
+| <a name="output_virtual_network_name"></a> [virtual\_network\_name](#output\_virtual\_network\_name) | n/a |
 <!-- END_TF_DOCS -->

--- a/aks/terraform/modules/network/README.md
+++ b/aks/terraform/modules/network/README.md
@@ -24,7 +24,9 @@ No modules.
 | [azurerm_route.cluster_secondary](https://registry.terraform.io/providers/hashicorp/azurerm/4.11.0/docs/resources/route) | resource |
 | [azurerm_route_table.cluster](https://registry.terraform.io/providers/hashicorp/azurerm/4.11.0/docs/resources/route_table) | resource |
 | [azurerm_subnet.cluster](https://registry.terraform.io/providers/hashicorp/azurerm/4.11.0/docs/resources/subnet) | resource |
+| [azurerm_subnet.cluster_secondary](https://registry.terraform.io/providers/hashicorp/azurerm/4.11.0/docs/resources/subnet) | resource |
 | [azurerm_subnet_route_table_association.cluster](https://registry.terraform.io/providers/hashicorp/azurerm/4.11.0/docs/resources/subnet_route_table_association) | resource |
+| [azurerm_subnet_route_table_association.cluster_secondary](https://registry.terraform.io/providers/hashicorp/azurerm/4.11.0/docs/resources/subnet_route_table_association) | resource |
 | [azurerm_virtual_network.this](https://registry.terraform.io/providers/hashicorp/azurerm/4.11.0/docs/resources/virtual_network) | resource |
 
 ## Inputs
@@ -37,6 +39,7 @@ No modules.
 | <a name="input_create_network"></a> [create\_network](#input\_create\_network) | When set to false, networking (VNET, Subnets, etc) must be created externally. | `bool` | `true` | no |
 | <a name="input_region"></a> [region](#input\_region) | The Azure region where this network will reside. | `string` | n/a | yes |
 | <a name="input_resource_group_name"></a> [resource\_group\_name](#input\_resource\_group\_name) | The name of the resource group that will contain the network. | `string` | n/a | yes |
+| <a name="input_secondary_cluster_subnet_cidr"></a> [secondary\_cluster\_subnet\_cidr](#input\_secondary\_cluster\_subnet\_cidr) | The CIDR of the secondary cluster subnet. Required when secondary\_vnet\_cidr is set. | `string` | `null` | no |
 | <a name="input_secondary_vnet_cidr"></a> [secondary\_vnet\_cidr](#input\_secondary\_vnet\_cidr) | An optional secondary CIDR block to associate with the cluster's VNET. This can be used to expand the cluster's available IP address space without needing to create a new VNET and migrate resources. | `string` | `null` | no |
 | <a name="input_vnet_cidr"></a> [vnet\_cidr](#input\_vnet\_cidr) | The CIDR of the cluster's VNET. | `string` | `null` | no |
 
@@ -45,5 +48,6 @@ No modules.
 | Name | Description |
 |------|-------------|
 | <a name="output_route_table_id"></a> [route\_table\_id](#output\_route\_table\_id) | n/a |
+| <a name="output_secondary_subnet_id"></a> [secondary\_subnet\_id](#output\_secondary\_subnet\_id) | n/a |
 | <a name="output_subnet_id"></a> [subnet\_id](#output\_subnet\_id) | n/a |
 <!-- END_TF_DOCS -->

--- a/aks/terraform/modules/network/README.md
+++ b/aks/terraform/modules/network/README.md
@@ -51,5 +51,5 @@ No modules.
 | <a name="output_route_table_id"></a> [route\_table\_id](#output\_route\_table\_id) | n/a |
 | <a name="output_secondary_subnet_id"></a> [secondary\_subnet\_id](#output\_secondary\_subnet\_id) | n/a |
 | <a name="output_subnet_id"></a> [subnet\_id](#output\_subnet\_id) | n/a |
-| <a name="output_virtual_network_name"></a> [virtual\_network\_name](#output\_virtual\_network\_name) | n/a |
+| <a name="output_virtual_network_id"></a> [virtual\_network\_id](#output\_virtual\_network\_id) | n/a |
 <!-- END_TF_DOCS -->

--- a/aks/terraform/modules/network/main.tf
+++ b/aks/terraform/modules/network/main.tf
@@ -5,12 +5,17 @@ resource "azurerm_virtual_network" "this" {
   location            = var.region
   resource_group_name = var.resource_group_name
   tags                = var.common_tags
-  address_space       = [var.vnet_cidr]
+  address_space       = var.secondary_vnet_cidr != null ? [var.vnet_cidr, var.secondary_vnet_cidr] : [var.vnet_cidr]
 
   lifecycle {
     precondition {
       condition     = can(cidrhost(var.vnet_cidr, 0))
       error_message = "A valid IPv4 CIDR must be provided for 'vnet_cidr' variable."
+    }
+
+    precondition {
+      condition     = var.secondary_vnet_cidr == null || can(cidrhost(var.secondary_vnet_cidr, 0))
+      error_message = "A valid IPv4 CIDR must be provided for 'secondary_vnet_cidr' variable if it is not null."
     }
   }
 }
@@ -58,5 +63,15 @@ resource "azurerm_route" "cluster" {
   resource_group_name = var.resource_group_name
   route_table_name    = azurerm_route_table.cluster[0].name
   address_prefix      = var.vnet_cidr
+  next_hop_type       = "VnetLocal"
+}
+
+resource "azurerm_route" "cluster_secondary" {
+  count = var.create_network && var.secondary_vnet_cidr != null ? 1 : 0
+
+  name                = "local-secondary"
+  resource_group_name = var.resource_group_name
+  route_table_name    = azurerm_route_table.cluster[0].name
+  address_prefix      = var.secondary_vnet_cidr
   next_hop_type       = "VnetLocal"
 }

--- a/aks/terraform/modules/network/main.tf
+++ b/aks/terraform/modules/network/main.tf
@@ -88,6 +88,17 @@ resource "azurerm_subnet" "cluster_secondary" {
 
   private_endpoint_network_policies = "Disabled"
 
+  dynamic "delegation" {
+    for_each = var.secondary_cluster_subnet_delegation != null ? [var.secondary_cluster_subnet_delegation] : []
+    content {
+      name = delegation.value.name
+      service_delegation {
+        name    = delegation.value.service_delegation.name
+        actions = delegation.value.service_delegation.actions
+      }
+    }
+  }
+
   depends_on = [azurerm_virtual_network.this]
 
   lifecycle {

--- a/aks/terraform/modules/network/main.tf
+++ b/aks/terraform/modules/network/main.tf
@@ -75,3 +75,37 @@ resource "azurerm_route" "cluster_secondary" {
   address_prefix      = var.secondary_vnet_cidr
   next_hop_type       = "VnetLocal"
 }
+
+resource "azurerm_subnet" "cluster_secondary" {
+  #checkov:skip=CKV2_AZURE_31:AKS manages the NSGs appled to worker nodes - having one on the subnet would require either manual management or overly permissive rules that would defeat the purpose
+
+  count = var.create_network && var.secondary_vnet_cidr != null ? 1 : 0
+
+  name                 = "cluster-secondary"
+  resource_group_name  = var.resource_group_name
+  virtual_network_name = azurerm_virtual_network.this[0].name
+  address_prefixes     = [var.secondary_cluster_subnet_cidr]
+
+  private_endpoint_network_policies = "Disabled"
+
+  depends_on = [azurerm_virtual_network.this]
+
+  lifecycle {
+    precondition {
+      condition     = var.secondary_cluster_subnet_cidr != null
+      error_message = "A valid IPv4 CIDR must be provided for 'secondary_cluster_subnet_cidr' variable when secondary_vnet_cidr is set."
+    }
+
+    precondition {
+      condition     = can(cidrhost(var.secondary_cluster_subnet_cidr, 0))
+      error_message = "A valid IPv4 CIDR must be provided for 'secondary_cluster_subnet_cidr' variable."
+    }
+  }
+}
+
+resource "azurerm_subnet_route_table_association" "cluster_secondary" {
+  count = var.create_network && var.secondary_vnet_cidr != null ? 1 : 0
+
+  subnet_id      = azurerm_subnet.cluster_secondary[0].id
+  route_table_id = azurerm_route_table.cluster[0].id
+}

--- a/aks/terraform/modules/network/main.tf
+++ b/aks/terraform/modules/network/main.tf
@@ -5,7 +5,7 @@ resource "azurerm_virtual_network" "this" {
   location            = var.region
   resource_group_name = var.resource_group_name
   tags                = var.common_tags
-  address_space       = var.secondary_vnet_cidr != null ? [var.vnet_cidr, var.secondary_vnet_cidr] : [var.vnet_cidr]
+  address_space       = var.database_vnet_cidr != null ? [var.vnet_cidr, var.database_vnet_cidr] : [var.vnet_cidr]
 
   lifecycle {
     precondition {
@@ -14,8 +14,8 @@ resource "azurerm_virtual_network" "this" {
     }
 
     precondition {
-      condition     = var.secondary_vnet_cidr == null || can(cidrhost(var.secondary_vnet_cidr, 0))
-      error_message = "A valid IPv4 CIDR must be provided for 'secondary_vnet_cidr' variable if it is not null."
+      condition     = var.database_vnet_cidr == null || can(cidrhost(var.database_vnet_cidr, 0))
+      error_message = "A valid IPv4 CIDR must be provided for 'database_vnet_cidr' variable if it is not null."
     }
   }
 }
@@ -66,30 +66,30 @@ resource "azurerm_route" "cluster" {
   next_hop_type       = "VnetLocal"
 }
 
-resource "azurerm_route" "cluster_secondary" {
-  count = var.create_network && var.secondary_vnet_cidr != null ? 1 : 0
+resource "azurerm_route" "database" {
+  count = var.create_network && var.database_vnet_cidr != null ? 1 : 0
 
-  name                = "local-secondary"
+  name                = "database"
   resource_group_name = var.resource_group_name
   route_table_name    = azurerm_route_table.cluster[0].name
-  address_prefix      = var.secondary_vnet_cidr
+  address_prefix      = var.database_vnet_cidr
   next_hop_type       = "VnetLocal"
 }
 
-resource "azurerm_subnet" "cluster_secondary" {
+resource "azurerm_subnet" "database" {
   #checkov:skip=CKV2_AZURE_31:AKS manages the NSGs appled to worker nodes - having one on the subnet would require either manual management or overly permissive rules that would defeat the purpose
 
-  count = var.create_network && var.secondary_vnet_cidr != null ? 1 : 0
+  count = var.create_network && var.database_vnet_cidr != null ? 1 : 0
 
-  name                 = "cluster-secondary"
+  name                 = "database"
   resource_group_name  = var.resource_group_name
   virtual_network_name = azurerm_virtual_network.this[0].name
-  address_prefixes     = [var.secondary_cluster_subnet_cidr]
+  address_prefixes     = [var.database_subnet_cidr]
 
   private_endpoint_network_policies = "Disabled"
 
   dynamic "delegation" {
-    for_each = var.secondary_cluster_subnet_delegation != null ? [var.secondary_cluster_subnet_delegation] : []
+    for_each = var.database_subnet_delegation != null ? [var.database_subnet_delegation] : []
     content {
       name = delegation.value.name
       service_delegation {
@@ -103,20 +103,20 @@ resource "azurerm_subnet" "cluster_secondary" {
 
   lifecycle {
     precondition {
-      condition     = var.secondary_cluster_subnet_cidr != null
-      error_message = "A valid IPv4 CIDR must be provided for 'secondary_cluster_subnet_cidr' variable when secondary_vnet_cidr is set."
+      condition     = var.database_subnet_cidr != null
+      error_message = "A valid IPv4 CIDR must be provided for 'database_subnet_cidr' variable when database_vnet_cidr is set."
     }
 
     precondition {
-      condition     = can(cidrhost(var.secondary_cluster_subnet_cidr, 0))
-      error_message = "A valid IPv4 CIDR must be provided for 'secondary_cluster_subnet_cidr' variable."
+      condition     = can(cidrhost(var.database_subnet_cidr, 0))
+      error_message = "A valid IPv4 CIDR must be provided for 'database_subnet_cidr' variable."
     }
   }
 }
 
-resource "azurerm_subnet_route_table_association" "cluster_secondary" {
-  count = var.create_network && var.secondary_vnet_cidr != null ? 1 : 0
+resource "azurerm_subnet_route_table_association" "database" {
+  count = var.create_network && var.database_vnet_cidr != null ? 1 : 0
 
-  subnet_id      = azurerm_subnet.cluster_secondary[0].id
+  subnet_id      = azurerm_subnet.database[0].id
   route_table_id = azurerm_route_table.cluster[0].id
 }

--- a/aks/terraform/modules/network/outputs.tf
+++ b/aks/terraform/modules/network/outputs.tf
@@ -2,6 +2,10 @@ output "subnet_id" {
   value = var.create_network ? azurerm_subnet.cluster[0].id : null
 }
 
+output "secondary_subnet_id" {
+  value = var.create_network && var.secondary_vnet_cidr != null ? azurerm_subnet.cluster_secondary[0].id : null
+}
+
 output "route_table_id" {
   value = var.create_network ? azurerm_route_table.cluster[0].id : null
 }

--- a/aks/terraform/modules/network/outputs.tf
+++ b/aks/terraform/modules/network/outputs.tf
@@ -2,8 +2,8 @@ output "subnet_id" {
   value = var.create_network ? azurerm_subnet.cluster[0].id : null
 }
 
-output "secondary_subnet_id" {
-  value = var.create_network && var.secondary_vnet_cidr != null ? azurerm_subnet.cluster_secondary[0].id : null
+output "database_subnet_id" {
+  value = var.create_network && var.database_vnet_cidr != null ? azurerm_subnet.database[0].id : null
 }
 
 output "route_table_id" {

--- a/aks/terraform/modules/network/outputs.tf
+++ b/aks/terraform/modules/network/outputs.tf
@@ -10,6 +10,6 @@ output "route_table_id" {
   value = var.create_network ? azurerm_route_table.cluster[0].id : null
 }
 
-output "virtual_network_name" {
-  value = var.create_network ? azurerm_virtual_network.this[0].name : null
+output "virtual_network_id" {
+  value = var.create_network ? azurerm_virtual_network.this[0].id : null
 }

--- a/aks/terraform/modules/network/outputs.tf
+++ b/aks/terraform/modules/network/outputs.tf
@@ -9,3 +9,7 @@ output "secondary_subnet_id" {
 output "route_table_id" {
   value = var.create_network ? azurerm_route_table.cluster[0].id : null
 }
+
+output "virtual_network_name" {
+  value = var.create_network ? azurerm_virtual_network.this[0].name : null
+}

--- a/aks/terraform/modules/network/variables.tf
+++ b/aks/terraform/modules/network/variables.tf
@@ -31,6 +31,12 @@ variable "vnet_cidr" {
   description = "The CIDR of the cluster's VNET."
 }
 
+variable "secondary_vnet_cidr" {
+  type        = string
+  default     = null
+  description = "An optional secondary CIDR block to associate with the cluster's VNET. This can be used to expand the cluster's available IP address space without needing to create a new VNET and migrate resources."
+}
+
 variable "cluster_subnet_cidr" {
   type        = string
   default     = null

--- a/aks/terraform/modules/network/variables.tf
+++ b/aks/terraform/modules/network/variables.tf
@@ -31,10 +31,10 @@ variable "vnet_cidr" {
   description = "The CIDR of the cluster's VNET."
 }
 
-variable "secondary_vnet_cidr" {
+variable "database_vnet_cidr" {
   type        = string
   default     = null
-  description = "An optional secondary CIDR block to associate with the cluster's VNET. This can be used to expand the cluster's available IP address space without needing to create a new VNET and migrate resources."
+  description = "An optional database CIDR block to associate with the cluster's VNET. This can be used to expand the cluster's available IP address space without needing to create a new VNET and migrate resources."
 }
 
 variable "cluster_subnet_cidr" {
@@ -43,13 +43,13 @@ variable "cluster_subnet_cidr" {
   description = "The CIDR of the cluster's subnet."
 }
 
-variable "secondary_cluster_subnet_cidr" {
+variable "database_subnet_cidr" {
   type        = string
   default     = null
-  description = "The CIDR of the secondary cluster subnet. Required when secondary_vnet_cidr is set."
+  description = "The CIDR of the database subnet. Required when database_vnet_cidr is set."
 }
 
-variable "secondary_cluster_subnet_delegation" {
+variable "database_subnet_delegation" {
   type = object({
     name = string
     service_delegation = object({
@@ -58,5 +58,5 @@ variable "secondary_cluster_subnet_delegation" {
     })
   })
   default     = null
-  description = "Optional delegation configuration for the secondary cluster subnet."
+  description = "Optional delegation configuration for the database subnet."
 }

--- a/aks/terraform/modules/network/variables.tf
+++ b/aks/terraform/modules/network/variables.tf
@@ -42,3 +42,9 @@ variable "cluster_subnet_cidr" {
   default     = null
   description = "The CIDR of the cluster's subnet."
 }
+
+variable "secondary_cluster_subnet_cidr" {
+  type        = string
+  default     = null
+  description = "The CIDR of the secondary cluster subnet. Required when secondary_vnet_cidr is set."
+}

--- a/aks/terraform/modules/network/variables.tf
+++ b/aks/terraform/modules/network/variables.tf
@@ -48,3 +48,15 @@ variable "secondary_cluster_subnet_cidr" {
   default     = null
   description = "The CIDR of the secondary cluster subnet. Required when secondary_vnet_cidr is set."
 }
+
+variable "secondary_cluster_subnet_delegation" {
+  type = object({
+    name = string
+    service_delegation = object({
+      name    = string
+      actions = list(string)
+    })
+  })
+  default     = null
+  description = "Optional delegation configuration for the secondary cluster subnet."
+}

--- a/eks/terraform/modules/network/README.md
+++ b/eks/terraform/modules/network/README.md
@@ -30,6 +30,7 @@ No modules.
 | [aws_subnet.private](https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/subnet) | resource |
 | [aws_subnet.public](https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/subnet) | resource |
 | [aws_vpc.this](https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/vpc) | resource |
+| [aws_vpc_ipv4_cidr_block_association.secondary](https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/vpc_ipv4_cidr_block_association) | resource |
 | [aws_availability_zones.available](https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/data-sources/availability_zones) | data source |
 | [aws_availability_zones.preferred](https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/data-sources/availability_zones) | data source |
 
@@ -42,6 +43,7 @@ No modules.
 | <a name="input_preferred_availability_zone_ids"></a> [preferred\_availability\_zone\_ids](#input\_preferred\_availability\_zone\_ids) | The preferred availability zones to use for the created subnets, specified by ZoneId (eg. 'use1-az1') -- not ZoneName (eg. 'us-east-1a'). If no specific zones are required, leave empty. | `list(string)` | `[]` | no |
 | <a name="input_private_subnet_cidrs"></a> [private\_subnet\_cidrs](#input\_private\_subnet\_cidrs) | The CIDRs of the three private subnets. These will contain the EKS cluster's master ENIs, worker nodes, and internal load-balancer ENIs (if desired). | `list(string)` | `[]` | no |
 | <a name="input_public_subnet_cidrs"></a> [public\_subnet\_cidrs](#input\_public\_subnet\_cidrs) | The CIDRs of the three public subnets. These will contain the bastion host, NAT gateways, and internet-facing load balancer ENIs (if desired). | `list(string)` | `[]` | no |
+| <a name="input_secondary_vpc_cidr"></a> [secondary\_vpc\_cidr](#input\_secondary\_vpc\_cidr) | An optional secondary CIDR block to associate with the cluster's VPC. This can be used to expand the cluster's available IP address space without needing to create a new VPC and migrate resources. | `string` | `null` | no |
 | <a name="input_vpc_cidr"></a> [vpc\_cidr](#input\_vpc\_cidr) | The CIDR of the cluster's VPC. | `string` | `null` | no |
 
 ## Outputs

--- a/eks/terraform/modules/network/README.md
+++ b/eks/terraform/modules/network/README.md
@@ -21,14 +21,22 @@ No modules.
 | Name | Type |
 |------|------|
 | [aws_eip.nat](https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/eip) | resource |
+| [aws_eip.secondary_nat](https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/eip) | resource |
 | [aws_internet_gateway.gateway](https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/internet_gateway) | resource |
 | [aws_nat_gateway.nat](https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/nat_gateway) | resource |
+| [aws_nat_gateway.secondary_nat](https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/nat_gateway) | resource |
 | [aws_route_table.private](https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/route_table) | resource |
 | [aws_route_table.public](https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/route_table) | resource |
+| [aws_route_table.secondary_private](https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/route_table) | resource |
+| [aws_route_table.secondary_public](https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/route_table) | resource |
 | [aws_route_table_association.private](https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/route_table_association) | resource |
 | [aws_route_table_association.public](https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/route_table_association) | resource |
+| [aws_route_table_association.secondary_private](https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/route_table_association) | resource |
+| [aws_route_table_association.secondary_public](https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/route_table_association) | resource |
 | [aws_subnet.private](https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/subnet) | resource |
 | [aws_subnet.public](https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/subnet) | resource |
+| [aws_subnet.secondary_private](https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/subnet) | resource |
+| [aws_subnet.secondary_public](https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/subnet) | resource |
 | [aws_vpc.this](https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/vpc) | resource |
 | [aws_vpc_ipv4_cidr_block_association.secondary](https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/vpc_ipv4_cidr_block_association) | resource |
 | [aws_availability_zones.available](https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/data-sources/availability_zones) | data source |
@@ -43,6 +51,8 @@ No modules.
 | <a name="input_preferred_availability_zone_ids"></a> [preferred\_availability\_zone\_ids](#input\_preferred\_availability\_zone\_ids) | The preferred availability zones to use for the created subnets, specified by ZoneId (eg. 'use1-az1') -- not ZoneName (eg. 'us-east-1a'). If no specific zones are required, leave empty. | `list(string)` | `[]` | no |
 | <a name="input_private_subnet_cidrs"></a> [private\_subnet\_cidrs](#input\_private\_subnet\_cidrs) | The CIDRs of the three private subnets. These will contain the EKS cluster's master ENIs, worker nodes, and internal load-balancer ENIs (if desired). | `list(string)` | `[]` | no |
 | <a name="input_public_subnet_cidrs"></a> [public\_subnet\_cidrs](#input\_public\_subnet\_cidrs) | The CIDRs of the three public subnets. These will contain the bastion host, NAT gateways, and internet-facing load balancer ENIs (if desired). | `list(string)` | `[]` | no |
+| <a name="input_secondary_private_subnet_cidrs"></a> [secondary\_private\_subnet\_cidrs](#input\_secondary\_private\_subnet\_cidrs) | The CIDRs of the three private subnets from the secondary CIDR block. These will contain worker nodes and internal load-balancer ENIs (if desired). | `list(string)` | `[]` | no |
+| <a name="input_secondary_public_subnet_cidrs"></a> [secondary\_public\_subnet\_cidrs](#input\_secondary\_public\_subnet\_cidrs) | The CIDRs of the three public subnets from the secondary CIDR block. These will contain NAT gateways and internet-facing load balancer ENIs (if desired). | `list(string)` | `[]` | no |
 | <a name="input_secondary_vpc_cidr"></a> [secondary\_vpc\_cidr](#input\_secondary\_vpc\_cidr) | An optional secondary CIDR block to associate with the cluster's VPC. This can be used to expand the cluster's available IP address space without needing to create a new VPC and migrate resources. | `string` | `null` | no |
 | <a name="input_vpc_cidr"></a> [vpc\_cidr](#input\_vpc\_cidr) | The CIDR of the cluster's VPC. | `string` | `null` | no |
 
@@ -52,5 +62,7 @@ No modules.
 |------|-------------|
 | <a name="output_private_subnets"></a> [private\_subnets](#output\_private\_subnets) | n/a |
 | <a name="output_public_subnets"></a> [public\_subnets](#output\_public\_subnets) | n/a |
+| <a name="output_secondary_private_subnets"></a> [secondary\_private\_subnets](#output\_secondary\_private\_subnets) | n/a |
+| <a name="output_secondary_public_subnets"></a> [secondary\_public\_subnets](#output\_secondary\_public\_subnets) | n/a |
 | <a name="output_vpc_id"></a> [vpc\_id](#output\_vpc\_id) | n/a |
 <!-- END_TF_DOCS -->

--- a/eks/terraform/modules/network/README.md
+++ b/eks/terraform/modules/network/README.md
@@ -21,22 +21,17 @@ No modules.
 | Name | Type |
 |------|------|
 | [aws_eip.nat](https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/eip) | resource |
-| [aws_eip.secondary_nat](https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/eip) | resource |
 | [aws_internet_gateway.gateway](https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/internet_gateway) | resource |
 | [aws_nat_gateway.nat](https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/nat_gateway) | resource |
-| [aws_nat_gateway.secondary_nat](https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/nat_gateway) | resource |
 | [aws_route_table.private](https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/route_table) | resource |
 | [aws_route_table.public](https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/route_table) | resource |
 | [aws_route_table.secondary_private](https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/route_table) | resource |
-| [aws_route_table.secondary_public](https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/route_table) | resource |
 | [aws_route_table_association.private](https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/route_table_association) | resource |
 | [aws_route_table_association.public](https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/route_table_association) | resource |
 | [aws_route_table_association.secondary_private](https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/route_table_association) | resource |
-| [aws_route_table_association.secondary_public](https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/route_table_association) | resource |
 | [aws_subnet.private](https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/subnet) | resource |
 | [aws_subnet.public](https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/subnet) | resource |
 | [aws_subnet.secondary_private](https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/subnet) | resource |
-| [aws_subnet.secondary_public](https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/subnet) | resource |
 | [aws_vpc.this](https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/vpc) | resource |
 | [aws_vpc_ipv4_cidr_block_association.secondary](https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/vpc_ipv4_cidr_block_association) | resource |
 | [aws_availability_zones.available](https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/data-sources/availability_zones) | data source |
@@ -51,8 +46,7 @@ No modules.
 | <a name="input_preferred_availability_zone_ids"></a> [preferred\_availability\_zone\_ids](#input\_preferred\_availability\_zone\_ids) | The preferred availability zones to use for the created subnets, specified by ZoneId (eg. 'use1-az1') -- not ZoneName (eg. 'us-east-1a'). If no specific zones are required, leave empty. | `list(string)` | `[]` | no |
 | <a name="input_private_subnet_cidrs"></a> [private\_subnet\_cidrs](#input\_private\_subnet\_cidrs) | The CIDRs of the three private subnets. These will contain the EKS cluster's master ENIs, worker nodes, and internal load-balancer ENIs (if desired). | `list(string)` | `[]` | no |
 | <a name="input_public_subnet_cidrs"></a> [public\_subnet\_cidrs](#input\_public\_subnet\_cidrs) | The CIDRs of the three public subnets. These will contain the bastion host, NAT gateways, and internet-facing load balancer ENIs (if desired). | `list(string)` | `[]` | no |
-| <a name="input_secondary_private_subnet_cidrs"></a> [secondary\_private\_subnet\_cidrs](#input\_secondary\_private\_subnet\_cidrs) | The CIDRs of the three private subnets from the secondary CIDR block. These will contain worker nodes and internal load-balancer ENIs (if desired). | `list(string)` | `[]` | no |
-| <a name="input_secondary_public_subnet_cidrs"></a> [secondary\_public\_subnet\_cidrs](#input\_secondary\_public\_subnet\_cidrs) | The CIDRs of the three public subnets from the secondary CIDR block. These will contain NAT gateways and internet-facing load balancer ENIs (if desired). | `list(string)` | `[]` | no |
+| <a name="input_secondary_private_subnet_cidrs"></a> [secondary\_private\_subnet\_cidrs](#input\_secondary\_private\_subnet\_cidrs) | The CIDRs of the three private subnets from the secondary CIDR block. These will contain worker nodes and internal load-balancer ENIs (if desired). These subnets will use the same NAT gateways as the primary private subnets. | `list(string)` | `[]` | no |
 | <a name="input_secondary_vpc_cidr"></a> [secondary\_vpc\_cidr](#input\_secondary\_vpc\_cidr) | An optional secondary CIDR block to associate with the cluster's VPC. This can be used to expand the cluster's available IP address space without needing to create a new VPC and migrate resources. | `string` | `null` | no |
 | <a name="input_vpc_cidr"></a> [vpc\_cidr](#input\_vpc\_cidr) | The CIDR of the cluster's VPC. | `string` | `null` | no |
 
@@ -63,6 +57,5 @@ No modules.
 | <a name="output_private_subnets"></a> [private\_subnets](#output\_private\_subnets) | n/a |
 | <a name="output_public_subnets"></a> [public\_subnets](#output\_public\_subnets) | n/a |
 | <a name="output_secondary_private_subnets"></a> [secondary\_private\_subnets](#output\_secondary\_private\_subnets) | n/a |
-| <a name="output_secondary_public_subnets"></a> [secondary\_public\_subnets](#output\_secondary\_public\_subnets) | n/a |
 | <a name="output_vpc_id"></a> [vpc\_id](#output\_vpc\_id) | n/a |
 <!-- END_TF_DOCS -->

--- a/eks/terraform/modules/network/main.tf
+++ b/eks/terraform/modules/network/main.tf
@@ -158,3 +158,109 @@ resource "aws_route_table_association" "private" {
   subnet_id      = aws_subnet.private[count.index].id
   route_table_id = aws_route_table.private[count.index].id
 }
+
+# Secondary CIDR Public Subnets
+resource "aws_subnet" "secondary_public" {
+  count = var.create_network && var.secondary_vpc_cidr != null ? 3 : 0
+
+  vpc_id            = aws_vpc.this[0].id
+  cidr_block        = var.secondary_public_subnet_cidrs[count.index]
+  availability_zone = local.selected_availability_zones.names[count.index]
+
+  tags = {
+    Name                     = "${var.cluster_name}-secondary-public-${count.index}"
+    "kubernetes.io/role/elb" = "1"
+  }
+
+  depends_on = [aws_vpc_ipv4_cidr_block_association.secondary]
+
+  lifecycle {
+    precondition {
+      condition     = length(var.secondary_public_subnet_cidrs) == 3
+      error_message = "Three valid IPv4 CIDRs must be provided in the 'secondary_public_subnet_cidrs' variable when secondary_vpc_cidr is set."
+    }
+  }
+}
+
+# Secondary CIDR Private Subnets
+resource "aws_subnet" "secondary_private" {
+  count             = var.create_network && var.secondary_vpc_cidr != null ? 3 : 0
+  vpc_id            = aws_vpc.this[0].id
+  cidr_block        = var.secondary_private_subnet_cidrs[count.index]
+  availability_zone = local.selected_availability_zones.names[count.index]
+
+  tags = {
+    Name                              = "${var.cluster_name}-secondary-private-${count.index}"
+    "kubernetes.io/role/internal-elb" = "1"
+  }
+
+  depends_on = [aws_vpc_ipv4_cidr_block_association.secondary]
+
+  lifecycle {
+    precondition {
+      condition     = length(var.secondary_private_subnet_cidrs) == 3
+      error_message = "Three valid IPv4 CIDRs must be provided in the 'secondary_private_subnet_cidrs' variable when secondary_vpc_cidr is set."
+    }
+  }
+}
+
+# EIPs for Secondary NAT Gateways
+resource "aws_eip" "secondary_nat" {
+  #checkov:skip=CKV2_AWS_19:False positive - the EIPs are assoicated with the NAT Gateways below
+  count = var.create_network && var.secondary_vpc_cidr != null ? 3 : 0
+}
+
+# Secondary NAT Gateways (one per secondary public subnet)
+resource "aws_nat_gateway" "secondary_nat" {
+  count = var.create_network && var.secondary_vpc_cidr != null ? 3 : 0
+
+  allocation_id = aws_eip.secondary_nat[count.index].id
+  subnet_id     = aws_subnet.secondary_public[count.index].id
+}
+
+# Route Table for Secondary Public Subnets (route to IGW)
+resource "aws_route_table" "secondary_public" {
+  count = var.create_network && var.secondary_vpc_cidr != null ? 1 : 0
+
+  vpc_id = aws_vpc.this[0].id
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.gateway[0].id
+  }
+
+  tags = {
+    Name = "${var.cluster_name}-secondary-public"
+  }
+}
+
+# Route Table Associations for Secondary Public Subnets
+resource "aws_route_table_association" "secondary_public" {
+  count = var.create_network && var.secondary_vpc_cidr != null ? length(aws_subnet.secondary_public) : 0
+
+  subnet_id      = aws_subnet.secondary_public[count.index].id
+  route_table_id = aws_route_table.secondary_public[0].id
+}
+
+# Route Tables for Secondary Private Subnets (route to NAT gateways)
+resource "aws_route_table" "secondary_private" {
+  count  = var.create_network && var.secondary_vpc_cidr != null ? 3 : 0
+  vpc_id = aws_vpc.this[0].id
+
+  route {
+    cidr_block     = "0.0.0.0/0"
+    nat_gateway_id = aws_nat_gateway.secondary_nat[count.index].id
+  }
+
+  tags = {
+    Name = "${var.cluster_name}-secondary-private-${count.index}"
+  }
+}
+
+# Route Table Associations for Secondary Private Subnets
+resource "aws_route_table_association" "secondary_private" {
+  count = var.create_network && var.secondary_vpc_cidr != null ? length(aws_subnet.secondary_private) : 0
+
+  subnet_id      = aws_subnet.secondary_private[count.index].id
+  route_table_id = aws_route_table.secondary_private[count.index].id
+}

--- a/eks/terraform/modules/network/main.tf
+++ b/eks/terraform/modules/network/main.tf
@@ -42,16 +42,16 @@ resource "aws_vpc" "this" {
   }
 }
 
-resource "aws_vpc_ipv4_cidr_block_association" "secondary" {
-  count = var.create_network && var.secondary_vpc_cidr != null ? 1 : 0
+resource "aws_vpc_ipv4_cidr_block_association" "database" {
+  count = var.create_network && var.database_vpc_cidr != null ? 1 : 0
 
   vpc_id     = aws_vpc.this[0].id
-  cidr_block = var.secondary_vpc_cidr
+  cidr_block = var.database_vpc_cidr
 
   lifecycle {
     precondition {
-      condition     = can(cidrhost(var.secondary_vpc_cidr, 0))
-      error_message = "A valid IPv4 CIDR must be provided for 'secondary_vpc_cidr' variable if it is not null."
+      condition     = can(cidrhost(var.database_vpc_cidr, 0))
+      error_message = "A valid IPv4 CIDR must be provided for 'database_vpc_cidr' variable if it is not null."
     }
   }
 }
@@ -159,46 +159,41 @@ resource "aws_route_table_association" "private" {
   route_table_id = aws_route_table.private[count.index].id
 }
 
-# Secondary CIDR Private Subnets
-resource "aws_subnet" "secondary_private" {
-  count             = var.create_network && var.secondary_vpc_cidr != null ? 3 : 0
+# Database Private Subnets
+resource "aws_subnet" "database_private" {
+  count             = var.create_network && var.database_vpc_cidr != null ? 3 : 0
   vpc_id            = aws_vpc.this[0].id
-  cidr_block        = var.secondary_private_subnet_cidrs[count.index]
+  cidr_block        = var.database_private_subnet_cidrs[count.index]
   availability_zone = local.selected_availability_zones.names[count.index]
 
   tags = {
-    Name = "${var.cluster_name}-secondary-private-${count.index}"
+    Name = "${var.cluster_name}-database-private-${count.index}"
   }
 
-  depends_on = [aws_vpc_ipv4_cidr_block_association.secondary]
+  depends_on = [aws_vpc_ipv4_cidr_block_association.database]
 
   lifecycle {
     precondition {
-      condition     = length(var.secondary_private_subnet_cidrs) == 3
-      error_message = "Three valid IPv4 CIDRs must be provided in the 'secondary_private_subnet_cidrs' variable when secondary_vpc_cidr is set."
+      condition     = length(var.database_private_subnet_cidrs) == 3
+      error_message = "Three valid IPv4 CIDRs must be provided in the 'database_private_subnet_cidrs' variable when database_vpc_cidr is set."
     }
   }
 }
 
-# Route Tables for Secondary Private Subnets (route to primary NAT gateways)
-resource "aws_route_table" "secondary_private" {
-  count  = var.create_network && var.secondary_vpc_cidr != null ? 3 : 0
+# Route Tables for Database Private Subnets (no internet access)
+resource "aws_route_table" "database_private" {
+  count  = var.create_network && var.database_vpc_cidr != null ? 3 : 0
   vpc_id = aws_vpc.this[0].id
 
-  route {
-    cidr_block     = "0.0.0.0/0"
-    nat_gateway_id = aws_nat_gateway.nat[count.index].id
-  }
-
   tags = {
-    Name = "${var.cluster_name}-secondary-private-${count.index}"
+    Name = "${var.cluster_name}-database-private-${count.index}"
   }
 }
 
-# Route Table Associations for Secondary Private Subnets
-resource "aws_route_table_association" "secondary_private" {
-  count = var.create_network && var.secondary_vpc_cidr != null ? length(aws_subnet.secondary_private) : 0
+# Route Table Associations for Database Private Subnets
+resource "aws_route_table_association" "database_private" {
+  count = var.create_network && var.database_vpc_cidr != null ? length(aws_subnet.database_private) : 0
 
-  subnet_id      = aws_subnet.secondary_private[count.index].id
-  route_table_id = aws_route_table.secondary_private[count.index].id
+  subnet_id      = aws_subnet.database_private[count.index].id
+  route_table_id = aws_route_table.database_private[count.index].id
 }

--- a/eks/terraform/modules/network/main.tf
+++ b/eks/terraform/modules/network/main.tf
@@ -159,29 +159,6 @@ resource "aws_route_table_association" "private" {
   route_table_id = aws_route_table.private[count.index].id
 }
 
-# Secondary CIDR Public Subnets
-resource "aws_subnet" "secondary_public" {
-  count = var.create_network && var.secondary_vpc_cidr != null ? 3 : 0
-
-  vpc_id            = aws_vpc.this[0].id
-  cidr_block        = var.secondary_public_subnet_cidrs[count.index]
-  availability_zone = local.selected_availability_zones.names[count.index]
-
-  tags = {
-    Name                     = "${var.cluster_name}-secondary-public-${count.index}"
-    "kubernetes.io/role/elb" = "1"
-  }
-
-  depends_on = [aws_vpc_ipv4_cidr_block_association.secondary]
-
-  lifecycle {
-    precondition {
-      condition     = length(var.secondary_public_subnet_cidrs) == 3
-      error_message = "Three valid IPv4 CIDRs must be provided in the 'secondary_public_subnet_cidrs' variable when secondary_vpc_cidr is set."
-    }
-  }
-}
-
 # Secondary CIDR Private Subnets
 resource "aws_subnet" "secondary_private" {
   count             = var.create_network && var.secondary_vpc_cidr != null ? 3 : 0
@@ -190,8 +167,7 @@ resource "aws_subnet" "secondary_private" {
   availability_zone = local.selected_availability_zones.names[count.index]
 
   tags = {
-    Name                              = "${var.cluster_name}-secondary-private-${count.index}"
-    "kubernetes.io/role/internal-elb" = "1"
+    Name = "${var.cluster_name}-secondary-private-${count.index}"
   }
 
   depends_on = [aws_vpc_ipv4_cidr_block_association.secondary]
@@ -204,52 +180,14 @@ resource "aws_subnet" "secondary_private" {
   }
 }
 
-# EIPs for Secondary NAT Gateways
-resource "aws_eip" "secondary_nat" {
-  #checkov:skip=CKV2_AWS_19:False positive - the EIPs are assoicated with the NAT Gateways below
-  count = var.create_network && var.secondary_vpc_cidr != null ? 3 : 0
-}
-
-# Secondary NAT Gateways (one per secondary public subnet)
-resource "aws_nat_gateway" "secondary_nat" {
-  count = var.create_network && var.secondary_vpc_cidr != null ? 3 : 0
-
-  allocation_id = aws_eip.secondary_nat[count.index].id
-  subnet_id     = aws_subnet.secondary_public[count.index].id
-}
-
-# Route Table for Secondary Public Subnets (route to IGW)
-resource "aws_route_table" "secondary_public" {
-  count = var.create_network && var.secondary_vpc_cidr != null ? 1 : 0
-
-  vpc_id = aws_vpc.this[0].id
-
-  route {
-    cidr_block = "0.0.0.0/0"
-    gateway_id = aws_internet_gateway.gateway[0].id
-  }
-
-  tags = {
-    Name = "${var.cluster_name}-secondary-public"
-  }
-}
-
-# Route Table Associations for Secondary Public Subnets
-resource "aws_route_table_association" "secondary_public" {
-  count = var.create_network && var.secondary_vpc_cidr != null ? length(aws_subnet.secondary_public) : 0
-
-  subnet_id      = aws_subnet.secondary_public[count.index].id
-  route_table_id = aws_route_table.secondary_public[0].id
-}
-
-# Route Tables for Secondary Private Subnets (route to NAT gateways)
+# Route Tables for Secondary Private Subnets (route to primary NAT gateways)
 resource "aws_route_table" "secondary_private" {
   count  = var.create_network && var.secondary_vpc_cidr != null ? 3 : 0
   vpc_id = aws_vpc.this[0].id
 
   route {
     cidr_block     = "0.0.0.0/0"
-    nat_gateway_id = aws_nat_gateway.secondary_nat[count.index].id
+    nat_gateway_id = aws_nat_gateway.nat[count.index].id
   }
 
   tags = {

--- a/eks/terraform/modules/network/main.tf
+++ b/eks/terraform/modules/network/main.tf
@@ -42,6 +42,20 @@ resource "aws_vpc" "this" {
   }
 }
 
+resource "aws_vpc_ipv4_cidr_block_association" "secondary" {
+  count = var.create_network && var.secondary_vpc_cidr != null ? 1 : 0
+
+  vpc_id     = aws_vpc.this[0].id
+  cidr_block = var.secondary_vpc_cidr
+
+  lifecycle {
+    precondition {
+      condition     = can(cidrhost(var.secondary_vpc_cidr, 0))
+      error_message = "A valid IPv4 CIDR must be provided for 'secondary_vpc_cidr' variable if it is not null."
+    }
+  }
+}
+
 resource "aws_internet_gateway" "gateway" {
   count = var.create_network ? 1 : 0
 

--- a/eks/terraform/modules/network/outputs.tf
+++ b/eks/terraform/modules/network/outputs.tf
@@ -11,3 +11,13 @@ output "private_subnets" {
 
   depends_on = [aws_nat_gateway.nat]
 }
+
+output "secondary_public_subnets" {
+  value = var.create_network && var.secondary_vpc_cidr != null ? aws_subnet.secondary_public[*].id : null
+}
+
+output "secondary_private_subnets" {
+  value = var.create_network && var.secondary_vpc_cidr != null ? aws_subnet.secondary_private[*].id : null
+
+  depends_on = [aws_nat_gateway.secondary_nat]
+}

--- a/eks/terraform/modules/network/outputs.tf
+++ b/eks/terraform/modules/network/outputs.tf
@@ -12,8 +12,6 @@ output "private_subnets" {
   depends_on = [aws_nat_gateway.nat]
 }
 
-output "secondary_private_subnets" {
-  value = var.create_network && var.secondary_vpc_cidr != null ? aws_subnet.secondary_private[*].id : null
-
-  depends_on = [aws_nat_gateway.nat]
+output "database_private_subnets" {
+  value = var.create_network && var.database_vpc_cidr != null ? aws_subnet.database_private[*].id : null
 }

--- a/eks/terraform/modules/network/outputs.tf
+++ b/eks/terraform/modules/network/outputs.tf
@@ -12,12 +12,8 @@ output "private_subnets" {
   depends_on = [aws_nat_gateway.nat]
 }
 
-output "secondary_public_subnets" {
-  value = var.create_network && var.secondary_vpc_cidr != null ? aws_subnet.secondary_public[*].id : null
-}
-
 output "secondary_private_subnets" {
   value = var.create_network && var.secondary_vpc_cidr != null ? aws_subnet.secondary_private[*].id : null
 
-  depends_on = [aws_nat_gateway.secondary_nat]
+  depends_on = [aws_nat_gateway.nat]
 }

--- a/eks/terraform/modules/network/variables.tf
+++ b/eks/terraform/modules/network/variables.tf
@@ -15,6 +15,12 @@ variable "vpc_cidr" {
   description = "The CIDR of the cluster's VPC."
 }
 
+variable "secondary_vpc_cidr" {
+  type        = string
+  default     = null
+  description = "An optional secondary CIDR block to associate with the cluster's VPC. This can be used to expand the cluster's available IP address space without needing to create a new VPC and migrate resources."
+}
+
 variable "public_subnet_cidrs" {
   type        = list(string)
   default     = []

--- a/eks/terraform/modules/network/variables.tf
+++ b/eks/terraform/modules/network/variables.tf
@@ -38,3 +38,15 @@ variable "preferred_availability_zone_ids" {
   default     = []
   description = "The preferred availability zones to use for the created subnets, specified by ZoneId (eg. 'use1-az1') -- not ZoneName (eg. 'us-east-1a'). If no specific zones are required, leave empty."
 }
+
+variable "secondary_public_subnet_cidrs" {
+  type        = list(string)
+  default     = []
+  description = "The CIDRs of the three public subnets from the secondary CIDR block. These will contain NAT gateways and internet-facing load balancer ENIs (if desired)."
+}
+
+variable "secondary_private_subnet_cidrs" {
+  type        = list(string)
+  default     = []
+  description = "The CIDRs of the three private subnets from the secondary CIDR block. These will contain worker nodes and internal load-balancer ENIs (if desired)."
+}

--- a/eks/terraform/modules/network/variables.tf
+++ b/eks/terraform/modules/network/variables.tf
@@ -39,14 +39,8 @@ variable "preferred_availability_zone_ids" {
   description = "The preferred availability zones to use for the created subnets, specified by ZoneId (eg. 'use1-az1') -- not ZoneName (eg. 'us-east-1a'). If no specific zones are required, leave empty."
 }
 
-variable "secondary_public_subnet_cidrs" {
-  type        = list(string)
-  default     = []
-  description = "The CIDRs of the three public subnets from the secondary CIDR block. These will contain NAT gateways and internet-facing load balancer ENIs (if desired)."
-}
-
 variable "secondary_private_subnet_cidrs" {
   type        = list(string)
   default     = []
-  description = "The CIDRs of the three private subnets from the secondary CIDR block. These will contain worker nodes and internal load-balancer ENIs (if desired)."
+  description = "The CIDRs of the three private subnets from the secondary CIDR block. These will contain worker nodes and internal load-balancer ENIs (if desired). These subnets will use the same NAT gateways as the primary private subnets."
 }

--- a/eks/terraform/modules/network/variables.tf
+++ b/eks/terraform/modules/network/variables.tf
@@ -15,10 +15,10 @@ variable "vpc_cidr" {
   description = "The CIDR of the cluster's VPC."
 }
 
-variable "secondary_vpc_cidr" {
+variable "database_vpc_cidr" {
   type        = string
   default     = null
-  description = "An optional secondary CIDR block to associate with the cluster's VPC. This can be used to expand the cluster's available IP address space without needing to create a new VPC and migrate resources."
+  description = "An optional database CIDR block to associate with the cluster's VPC. This can be used for database subnets that are isolated from the internet."
 }
 
 variable "public_subnet_cidrs" {
@@ -39,8 +39,8 @@ variable "preferred_availability_zone_ids" {
   description = "The preferred availability zones to use for the created subnets, specified by ZoneId (eg. 'use1-az1') -- not ZoneName (eg. 'us-east-1a'). If no specific zones are required, leave empty."
 }
 
-variable "secondary_private_subnet_cidrs" {
+variable "database_private_subnet_cidrs" {
   type        = list(string)
   default     = []
-  description = "The CIDRs of the three private subnets from the secondary CIDR block. These will contain worker nodes and internal load-balancer ENIs (if desired). These subnets will use the same NAT gateways as the primary private subnets."
+  description = "The CIDRs of the three database private subnets from the database CIDR block. These subnets are isolated without internet access for enhanced security."
 }

--- a/gke/terraform/modules/network/README.md
+++ b/gke/terraform/modules/network/README.md
@@ -25,6 +25,7 @@ No modules.
 | [google_compute_router.router](https://registry.terraform.io/providers/hashicorp/google/6.42.0/docs/resources/compute_router) | resource |
 | [google_compute_router_nat.nat](https://registry.terraform.io/providers/hashicorp/google/6.42.0/docs/resources/compute_router_nat) | resource |
 | [google_compute_subnetwork.cluster](https://registry.terraform.io/providers/hashicorp/google/6.42.0/docs/resources/compute_subnetwork) | resource |
+| [google_compute_subnetwork.secondary](https://registry.terraform.io/providers/hashicorp/google/6.42.0/docs/resources/compute_subnetwork) | resource |
 
 ## Inputs
 
@@ -36,6 +37,7 @@ No modules.
 | <a name="input_secondary_cidr_range_messaging_pods"></a> [secondary\_cidr\_range\_messaging\_pods](#input\_secondary\_cidr\_range\_messaging\_pods) | The secondary CIDR range for the cluster's messaging node pools, if a separate range is desired. | `string` | `null` | no |
 | <a name="input_secondary_cidr_range_pods"></a> [secondary\_cidr\_range\_pods](#input\_secondary\_cidr\_range\_pods) | The secondary CIDR range for the cluster's pods. If a separate CIDR range is provided for messaging pods, this range will be used for just the system (default) node pool. | `string` | `null` | no |
 | <a name="input_secondary_cidr_range_services"></a> [secondary\_cidr\_range\_services](#input\_secondary\_cidr\_range\_services) | The secondary CIDR range for the cluster's services. | `string` | `null` | no |
+| <a name="input_secondary_network_cidr_range"></a> [secondary\_network\_cidr\_range](#input\_secondary\_network\_cidr\_range) | An optional secondary CIDR block for an additional subnetwork. This can be used to expand the cluster's available IP address space without needing to create a new VPC and migrate resources. | `string` | `null` | no |
 
 ## Outputs
 

--- a/gke/terraform/modules/network/README.md
+++ b/gke/terraform/modules/network/README.md
@@ -37,7 +37,8 @@ No modules.
 | <a name="input_secondary_cidr_range_messaging_pods"></a> [secondary\_cidr\_range\_messaging\_pods](#input\_secondary\_cidr\_range\_messaging\_pods) | The secondary CIDR range for the cluster's messaging node pools, if a separate range is desired. | `string` | `null` | no |
 | <a name="input_secondary_cidr_range_pods"></a> [secondary\_cidr\_range\_pods](#input\_secondary\_cidr\_range\_pods) | The secondary CIDR range for the cluster's pods. If a separate CIDR range is provided for messaging pods, this range will be used for just the system (default) node pool. | `string` | `null` | no |
 | <a name="input_secondary_cidr_range_services"></a> [secondary\_cidr\_range\_services](#input\_secondary\_cidr\_range\_services) | The secondary CIDR range for the cluster's services. | `string` | `null` | no |
-| <a name="input_secondary_network_cidr_range"></a> [secondary\_network\_cidr\_range](#input\_secondary\_network\_cidr\_range) | An optional secondary CIDR block for an additional subnetwork. This can be used to expand the cluster's available IP address space without needing to create a new VPC and migrate resources. | `string` | `null` | no |
+| <a name="input_secondary_cluster_subnetwork_cidr"></a> [secondary\_cluster\_subnetwork\_cidr](#input\_secondary\_cluster\_subnetwork\_cidr) | The CIDR of the secondary cluster subnetwork. This should be a subset of secondary\_network\_cidr\_range to leave space for other use cases. | `string` | `null` | no |
+| <a name="input_secondary_network_cidr_range"></a> [secondary\_network\_cidr\_range](#input\_secondary\_network\_cidr\_range) | An optional secondary CIDR block for the cluster's VPC. This can be used to expand the cluster's available IP address space without needing to create a new VPC and migrate resources. | `string` | `null` | no |
 
 ## Outputs
 

--- a/gke/terraform/modules/network/README.md
+++ b/gke/terraform/modules/network/README.md
@@ -44,6 +44,7 @@ No modules.
 
 | Name | Description |
 |------|-------------|
+| <a name="output_network_id"></a> [network\_id](#output\_network\_id) | n/a |
 | <a name="output_network_name"></a> [network\_name](#output\_network\_name) | n/a |
 | <a name="output_secondary_cidr_range_name_pods"></a> [secondary\_cidr\_range\_name\_pods](#output\_secondary\_cidr\_range\_name\_pods) | n/a |
 | <a name="output_secondary_range_name_messaging_pods"></a> [secondary\_range\_name\_messaging\_pods](#output\_secondary\_range\_name\_messaging\_pods) | n/a |

--- a/gke/terraform/modules/network/README.md
+++ b/gke/terraform/modules/network/README.md
@@ -47,5 +47,6 @@ No modules.
 | <a name="output_secondary_cidr_range_name_pods"></a> [secondary\_cidr\_range\_name\_pods](#output\_secondary\_cidr\_range\_name\_pods) | n/a |
 | <a name="output_secondary_range_name_messaging_pods"></a> [secondary\_range\_name\_messaging\_pods](#output\_secondary\_range\_name\_messaging\_pods) | n/a |
 | <a name="output_secondary_range_name_services"></a> [secondary\_range\_name\_services](#output\_secondary\_range\_name\_services) | n/a |
+| <a name="output_secondary_subnetwork_name"></a> [secondary\_subnetwork\_name](#output\_secondary\_subnetwork\_name) | n/a |
 | <a name="output_subnetwork_name"></a> [subnetwork\_name](#output\_subnetwork\_name) | n/a |
 <!-- END_TF_DOCS -->

--- a/gke/terraform/modules/network/main.tf
+++ b/gke/terraform/modules/network/main.tf
@@ -66,6 +66,26 @@ resource "google_compute_subnetwork" "cluster" {
   }
 }
 
+resource "google_compute_subnetwork" "secondary" {
+  #checkov:skip=CKV_GCP_76:This is not required, subnetwork is not configured to use ipv6
+  #checkov:skip=CKV_GCP_26:Solace is not opinionated on the use of VPC flow logs
+
+  count = var.create_network && var.secondary_network_cidr_range != null ? 1 : 0
+
+  name          = "${var.cluster_name}-secondary-subnetwork"
+  ip_cidr_range = var.secondary_network_cidr_range
+  network       = google_compute_network.this[0].name
+
+  private_ip_google_access = true
+
+  lifecycle {
+    precondition {
+      condition     = can(cidrhost(var.secondary_network_cidr_range, 0))
+      error_message = "A valid IPv4 CIDR must be provided for 'secondary_network_cidr_range' variable if it is not null."
+    }
+  }
+}
+
 resource "google_compute_router" "router" {
   count = var.create_network ? 1 : 0
 
@@ -93,5 +113,13 @@ resource "google_compute_router_nat" "nat" {
   subnetwork {
     name                    = google_compute_subnetwork.cluster[0].id
     source_ip_ranges_to_nat = ["ALL_IP_RANGES"]
+  }
+
+  dynamic "subnetwork" {
+    for_each = var.secondary_network_cidr_range != null ? [1] : []
+    content {
+      name                    = google_compute_subnetwork.secondary[0].id
+      source_ip_ranges_to_nat = ["ALL_IP_RANGES"]
+    }
   }
 }

--- a/gke/terraform/modules/network/main.tf
+++ b/gke/terraform/modules/network/main.tf
@@ -66,22 +66,22 @@ resource "google_compute_subnetwork" "cluster" {
   }
 }
 
-resource "google_compute_subnetwork" "secondary" {
+resource "google_compute_subnetwork" "database" {
   #checkov:skip=CKV_GCP_76:This is not required, subnetwork is not configured to use ipv6
   #checkov:skip=CKV_GCP_26:Solace is not opinionated on the use of VPC flow logs
 
-  count = var.create_network && var.secondary_network_cidr_range != null && var.secondary_cluster_subnetwork_cidr != null ? 1 : 0
+  count = var.create_network && var.database_network_cidr_range != null && var.database_subnetwork_cidr != null ? 1 : 0
 
-  name          = "${var.cluster_name}-secondary-subnetwork"
-  ip_cidr_range = var.secondary_cluster_subnetwork_cidr
+  name          = "${var.cluster_name}-database-subnetwork"
+  ip_cidr_range = var.database_subnetwork_cidr
   network       = google_compute_network.this[0].name
 
   private_ip_google_access = true
 
   lifecycle {
     precondition {
-      condition     = can(cidrhost(var.secondary_cluster_subnetwork_cidr, 0))
-      error_message = "A valid IPv4 CIDR must be provided for 'secondary_cluster_subnetwork_cidr' variable."
+      condition     = can(cidrhost(var.database_subnetwork_cidr, 0))
+      error_message = "A valid IPv4 CIDR must be provided for 'database_subnetwork_cidr' variable."
     }
   }
 }
@@ -113,13 +113,5 @@ resource "google_compute_router_nat" "nat" {
   subnetwork {
     name                    = google_compute_subnetwork.cluster[0].id
     source_ip_ranges_to_nat = ["ALL_IP_RANGES"]
-  }
-
-  dynamic "subnetwork" {
-    for_each = var.secondary_network_cidr_range != null && var.secondary_cluster_subnetwork_cidr != null ? [1] : []
-    content {
-      name                    = google_compute_subnetwork.secondary[0].id
-      source_ip_ranges_to_nat = ["ALL_IP_RANGES"]
-    }
   }
 }

--- a/gke/terraform/modules/network/main.tf
+++ b/gke/terraform/modules/network/main.tf
@@ -70,18 +70,18 @@ resource "google_compute_subnetwork" "secondary" {
   #checkov:skip=CKV_GCP_76:This is not required, subnetwork is not configured to use ipv6
   #checkov:skip=CKV_GCP_26:Solace is not opinionated on the use of VPC flow logs
 
-  count = var.create_network && var.secondary_network_cidr_range != null ? 1 : 0
+  count = var.create_network && var.secondary_network_cidr_range != null && var.secondary_cluster_subnetwork_cidr != null ? 1 : 0
 
   name          = "${var.cluster_name}-secondary-subnetwork"
-  ip_cidr_range = var.secondary_network_cidr_range
+  ip_cidr_range = var.secondary_cluster_subnetwork_cidr
   network       = google_compute_network.this[0].name
 
   private_ip_google_access = true
 
   lifecycle {
     precondition {
-      condition     = can(cidrhost(var.secondary_network_cidr_range, 0))
-      error_message = "A valid IPv4 CIDR must be provided for 'secondary_network_cidr_range' variable if it is not null."
+      condition     = can(cidrhost(var.secondary_cluster_subnetwork_cidr, 0))
+      error_message = "A valid IPv4 CIDR must be provided for 'secondary_cluster_subnetwork_cidr' variable."
     }
   }
 }
@@ -116,7 +116,7 @@ resource "google_compute_router_nat" "nat" {
   }
 
   dynamic "subnetwork" {
-    for_each = var.secondary_network_cidr_range != null ? [1] : []
+    for_each = var.secondary_network_cidr_range != null && var.secondary_cluster_subnetwork_cidr != null ? [1] : []
     content {
       name                    = google_compute_subnetwork.secondary[0].id
       source_ip_ranges_to_nat = ["ALL_IP_RANGES"]

--- a/gke/terraform/modules/network/outputs.tf
+++ b/gke/terraform/modules/network/outputs.tf
@@ -7,7 +7,7 @@ output "subnetwork_name" {
 }
 
 output "secondary_subnetwork_name" {
-  value = var.create_network && var.secondary_network_cidr_range != null ? google_compute_subnetwork.secondary[0].name : null
+  value = var.create_network && var.secondary_network_cidr_range != null && var.secondary_cluster_subnetwork_cidr != null ? google_compute_subnetwork.secondary[0].name : null
 }
 
 output "secondary_cidr_range_name_pods" {

--- a/gke/terraform/modules/network/outputs.tf
+++ b/gke/terraform/modules/network/outputs.tf
@@ -6,6 +6,10 @@ output "subnetwork_name" {
   value = var.create_network ? google_compute_subnetwork.cluster[0].name : null
 }
 
+output "secondary_subnetwork_name" {
+  value = var.create_network && var.secondary_network_cidr_range != null ? google_compute_subnetwork.secondary[0].name : null
+}
+
 output "secondary_cidr_range_name_pods" {
   value = var.create_network ? local.secondary_cidr_range_name_pods : null
 }

--- a/gke/terraform/modules/network/outputs.tf
+++ b/gke/terraform/modules/network/outputs.tf
@@ -10,8 +10,8 @@ output "subnetwork_name" {
   value = var.create_network ? google_compute_subnetwork.cluster[0].name : null
 }
 
-output "secondary_subnetwork_name" {
-  value = var.create_network && var.secondary_network_cidr_range != null && var.secondary_cluster_subnetwork_cidr != null ? google_compute_subnetwork.secondary[0].name : null
+output "database_subnetwork_name" {
+  value = var.create_network && var.database_network_cidr_range != null && var.database_subnetwork_cidr != null ? google_compute_subnetwork.database[0].name : null
 }
 
 output "secondary_cidr_range_name_pods" {

--- a/gke/terraform/modules/network/outputs.tf
+++ b/gke/terraform/modules/network/outputs.tf
@@ -2,6 +2,10 @@ output "network_name" {
   value = var.create_network ? google_compute_network.this[0].name : null
 }
 
+output "network_id" {
+  value = var.create_network ? google_compute_network.this[0].id : null
+}
+
 output "subnetwork_name" {
   value = var.create_network ? google_compute_subnetwork.cluster[0].name : null
 }

--- a/gke/terraform/modules/network/variables.tf
+++ b/gke/terraform/modules/network/variables.tf
@@ -18,7 +18,13 @@ variable "network_cidr_range" {
 variable "secondary_network_cidr_range" {
   type        = string
   default     = null
-  description = "An optional secondary CIDR block for an additional subnetwork. This can be used to expand the cluster's available IP address space without needing to create a new VPC and migrate resources."
+  description = "An optional secondary CIDR block for the cluster's VPC. This can be used to expand the cluster's available IP address space without needing to create a new VPC and migrate resources."
+}
+
+variable "secondary_cluster_subnetwork_cidr" {
+  type        = string
+  default     = null
+  description = "The CIDR of the secondary cluster subnetwork. This should be a subset of secondary_network_cidr_range to leave space for other use cases."
 }
 
 variable "secondary_cidr_range_services" {

--- a/gke/terraform/modules/network/variables.tf
+++ b/gke/terraform/modules/network/variables.tf
@@ -15,6 +15,12 @@ variable "network_cidr_range" {
   description = "The CIDR for the cluster's network."
 }
 
+variable "secondary_network_cidr_range" {
+  type        = string
+  default     = null
+  description = "An optional secondary CIDR block for an additional subnetwork. This can be used to expand the cluster's available IP address space without needing to create a new VPC and migrate resources."
+}
+
 variable "secondary_cidr_range_services" {
   type        = string
   default     = null

--- a/gke/terraform/modules/network/variables.tf
+++ b/gke/terraform/modules/network/variables.tf
@@ -15,16 +15,16 @@ variable "network_cidr_range" {
   description = "The CIDR for the cluster's network."
 }
 
-variable "secondary_network_cidr_range" {
+variable "database_network_cidr_range" {
   type        = string
   default     = null
-  description = "An optional secondary CIDR block for the cluster's VPC. This can be used to expand the cluster's available IP address space without needing to create a new VPC and migrate resources."
+  description = "An optional database CIDR block for the cluster's VPC. This can be used to expand the cluster's available IP address space without needing to create a new VPC and migrate resources."
 }
 
-variable "secondary_cluster_subnetwork_cidr" {
+variable "database_subnetwork_cidr" {
   type        = string
   default     = null
-  description = "The CIDR of the secondary cluster subnetwork. This should be a subset of secondary_network_cidr_range to leave space for other use cases."
+  description = "The CIDR of the database subnetwork. This should be a subset of database_network_cidr_range to leave space for other use cases."
 }
 
 variable "secondary_cidr_range_services" {


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:
This PR is to add secondary CIDR block for EKS, AKS and GKE. This is required to accommodate the infrastructure for SAM persistence.

#### Which issue(s) this PR fixes:


#### Special notes for your reviewer:
