### PR TITLE
Bump terraform-aws-modules/eks-pod-identity/aws to 2.8.0 for K8s 1.35

### DIFF
--- a/eks/terraform/modules/cluster-addons/main.tf
+++ b/eks/terraform/modules/cluster-addons/main.tf
@@ -12,7 +12,7 @@ locals {
 
 module "cluster_autoscaler_pod_identity" {
   source  = "terraform-aws-modules/eks-pod-identity/aws"
-  version = "1.12.1"
+  version = "2.8.0"
 
   name               = "${var.cluster_name}-ca"
   policy_name_prefix = "${var.cluster_name}-"
@@ -35,7 +35,7 @@ module "cluster_autoscaler_pod_identity" {
 
 module "aws_lb_controller_pod_identity" {
   source  = "terraform-aws-modules/eks-pod-identity/aws"
-  version = "1.12.1"
+  version = "2.8.0"
 
   name               = "${var.cluster_name}-lbc"
   policy_name_prefix = "${var.cluster_name}-"
@@ -58,7 +58,7 @@ module "aws_lb_controller_pod_identity" {
 
 module "aws_ebs_csi_pod_identity" {
   source  = "terraform-aws-modules/eks-pod-identity/aws"
-  version = "1.12.1"
+  version = "2.8.0"
 
   name               = "${var.cluster_name}-ebs-csi"
   policy_name_prefix = "${var.cluster_name}-"
@@ -80,7 +80,7 @@ module "aws_ebs_csi_pod_identity" {
 
 module "aws_vpc_cni_pod_identity" {
   source  = "terraform-aws-modules/eks-pod-identity/aws"
-  version = "1.12.1"
+  version = "2.8.0"
 
   name               = "${var.cluster_name}-vpc-cni"
   policy_name_prefix = "${var.cluster_name}-"


### PR DESCRIPTION
Update all four pod-identity module blocks (cluster_autoscaler, aws_lb_controller, aws_ebs_csi, aws_vpc_cni) from 1.12.1 to 2.8.0 to support Kubernetes 1.35.

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:
